### PR TITLE
Added -p option for put_object to prepend path to object name

### DIFF
--- a/src/main/java/com/spectralogic/ds3cli/Arguments.java
+++ b/src/main/java/com/spectralogic/ds3cli/Arguments.java
@@ -83,7 +83,7 @@ public class Arguments {
         directory.setArgName("directory");
         final Option objectName = new Option("o", true, "The name of the object to be retrieved or stored");
         objectName.setArgName("objectFileName");
-        final Option prefix = new Option("p", true, "Restores only objects who's names start with prefix.  Used with `get_bulk` and 'put_object'");
+        final Option prefix = new Option("p", true, "Used with 'get_bulk' to restore only objects who's names start with prefix.  Also used with 'bulk_put' and 'put_object' to add a prefix to object name(s)");
         prefix.setArgName("prefix");
         final Option proxy = new Option("x", true, "The URL of the proxy server to use or have \"http_proxy\" set as an environment variable");
         proxy.setArgName("proxy");

--- a/src/main/java/com/spectralogic/ds3cli/Arguments.java
+++ b/src/main/java/com/spectralogic/ds3cli/Arguments.java
@@ -83,7 +83,7 @@ public class Arguments {
         directory.setArgName("directory");
         final Option objectName = new Option("o", true, "The name of the object to be retrieved or stored");
         objectName.setArgName("objectFileName");
-        final Option prefix = new Option("p", true, "Restores only objects who's names start with prefix.  Used with `get_bulk`");
+        final Option prefix = new Option("p", true, "Restores only objects who's names start with prefix.  Used with `get_bulk` and 'put_object'");
         prefix.setArgName("prefix");
         final Option proxy = new Option("x", true, "The URL of the proxy server to use or have \"http_proxy\" set as an environment variable");
         proxy.setArgName("proxy");

--- a/src/main/java/com/spectralogic/ds3cli/command/PutObject.java
+++ b/src/main/java/com/spectralogic/ds3cli/command/PutObject.java
@@ -41,6 +41,7 @@ public class PutObject extends CliCommand<PutObjectResult> {
     private String bucketName;
     private Path objectPath;
     private String objectName;
+    private String prefix;
 
     public PutObject(final Ds3Provider provider, final FileUtils fileUtils) {
         super(provider, fileUtils);
@@ -68,6 +69,9 @@ public class PutObject extends CliCommand<PutObjectResult> {
         if (!getFileUtils().isRegularFile(objectPath)) {
             throw new BadArgumentException("The '-o' command must be a file and not a directory.");
         }
+
+        this.prefix = args.getPrefix();
+
         return this;
     }
 
@@ -76,6 +80,12 @@ public class PutObject extends CliCommand<PutObjectResult> {
     public PutObjectResult call() throws Exception {
         final Ds3ClientHelpers helpers = getClientHelpers();
         final Ds3Object ds3Obj = new Ds3Object(normalizeObjectName(objectName), getFileUtils().size(objectPath));
+
+        if(prefix != null) {
+            LOG.info("Pre-appending " + prefix + " to object name");
+            ds3Obj.setName(prefix + ds3Obj.getName());
+        }
+
         final Ds3ClientHelpers.Job putJob = helpers.startWriteJob(bucketName, Lists.newArrayList(ds3Obj));
         putJob.transfer(new Ds3ClientHelpers.ObjectChannelBuilder() {
             @Override


### PR DESCRIPTION
Unit Test:
BUILD SUCCESSFUL
Total time: 14.867 secs

Manual Integration Test:
Verified that prefix was added to file name when -p option was used.  Verified that nested directories could be created (ex: -p dir1/dir2/).  Also, verified that not using the prefix option maintained expected result (file added without prefix).