### PR TITLE
Added support for storing and retreiving the last modified field

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/Constants.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/Constants.java
@@ -1,0 +1,8 @@
+package com.spectralogic.ds3cli.command;
+
+/**
+ * Created by ryanmo on 2/29/16.
+ */
+public class Constants {
+    public static final String DS3_LAST_MODIFIED = "ds3-last-modified";
+}

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/Constants.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/Constants.java
@@ -1,8 +1,0 @@
-package com.spectralogic.ds3cli.command;
-
-/**
- * Created by ryanmo on 2/29/16.
- */
-public class Constants {
-    public static final String DS3_LAST_MODIFIED = "ds3-last-modified";
-}

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
@@ -229,9 +229,9 @@ public class GetBulk extends CliCommand<GetBulkResult> {
 
         @Override
         public void metadataReceived(final String filename, final Metadata metadata) {
-            if (metadata.keys().contains("ds3-last-modified")) {
+            if (metadata.keys().contains(Constants.DS3_LAST_MODIFIED)) {
                 try {
-                    final long lastModifiedMs = Long.parseLong(metadata.get("ds3-last-modified").get(0));
+                    final long lastModifiedMs = Long.parseLong(metadata.get(Constants.DS3_LAST_MODIFIED).get(0));
                     final Path path = outputPath.resolve(filename);
                     final FileTime lastModified = FileTime.from(lastModifiedMs, TimeUnit.MILLISECONDS);
                     Files.setLastModifiedTime(path, lastModified);

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
@@ -240,7 +240,7 @@ public class GetBulk extends CliCommand<GetBulkResult> {
                 }
 
             } else {
-                LOG.info("Object ("+ filename + ") does not contain a last modified field");
+                LOG.warn("Object ("+ filename + ") does not contain a last modified field");
             }
         }
     }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
@@ -27,7 +27,6 @@ import com.spectralogic.ds3client.helpers.options.ReadJobOptions;
 import com.spectralogic.ds3client.models.Contents;
 import com.spectralogic.ds3client.models.Priority;
 import com.spectralogic.ds3client.models.bulk.Ds3Object;
-import com.spectralogic.ds3client.networking.*;
 import com.spectralogic.ds3client.networking.Metadata;
 import com.spectralogic.ds3client.serializer.XmlProcessingException;
 import com.spectralogic.ds3client.utils.Guard;
@@ -39,15 +38,12 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
 import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 public class GetBulk extends CliCommand<GetBulkResult> {
 
@@ -229,19 +225,9 @@ public class GetBulk extends CliCommand<GetBulkResult> {
 
         @Override
         public void metadataReceived(final String filename, final Metadata metadata) {
-            if (metadata.keys().contains(Constants.DS3_LAST_MODIFIED)) {
-                try {
-                    final long lastModifiedMs = Long.parseLong(metadata.get(Constants.DS3_LAST_MODIFIED).get(0));
-                    final Path path = outputPath.resolve(filename);
-                    final FileTime lastModified = FileTime.from(lastModifiedMs, TimeUnit.MILLISECONDS);
-                    Files.setLastModifiedTime(path, lastModified);
-                } catch (final Throwable t) {
-                    LOG.error("Failed to restore the last modified date for object: " + filename, t);
-                }
-
-            } else {
-                LOG.warn("Object ("+ filename + ") does not contain a last modified field");
-            }
+            final Path path = outputPath.resolve(filename);
+            Utils.restoreLastModified(filename, metadata, path);
         }
     }
+
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
@@ -397,7 +397,7 @@ public class PutBulk extends CliCommand<PutBulkResult> {
     private static Map<String, String> getMetadataValues(final Path path) {
         try {
             final FileTime lastModifiedTime = Files.getLastModifiedTime(path);
-            return ImmutableMap.of("ds3-last-modified", Long.toString(lastModifiedTime.toMillis()));
+            return ImmutableMap.of(Constants.DS3_LAST_MODIFIED, Long.toString(lastModifiedTime.toMillis()));
         } catch (final IOException e) {
             LOG.error("Could not get the last modified time for file: " + path, e);
             return null;

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.*;
-import java.nio.file.attribute.FileTime;
 import java.security.SignatureException;
 import java.util.Map;
 
@@ -300,7 +299,7 @@ public class PutBulk extends CliCommand<PutBulkResult> {
             final String unPrefixedFile = removePrefix(fileName);
 
             final Path path = inputDirectory.resolve(unPrefixedFile);
-            return getMetadataValues(path);
+            return Utils.getMetadataValues(path);
         }
 
         private String removePrefix(final String fileName) {
@@ -390,17 +389,7 @@ public class PutBulk extends CliCommand<PutBulkResult> {
         @Override
         public Map<String, String> getMetadataValue(final String s) {
             final Path path = Paths.get(this.mapNormalizedObjectNameToObjectName.get(s));
-            return getMetadataValues(path);
-        }
-    }
-
-    private static Map<String, String> getMetadataValues(final Path path) {
-        try {
-            final FileTime lastModifiedTime = Files.getLastModifiedTime(path);
-            return ImmutableMap.of(Constants.DS3_LAST_MODIFIED, Long.toString(lastModifiedTime.toMillis()));
-        } catch (final IOException e) {
-            LOG.error("Could not get the last modified time for file: " + path, e);
-            return null;
+            return Utils.getMetadataValues(path);
         }
     }
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
@@ -40,11 +40,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
+import java.nio.file.attribute.FileTime;
 import java.security.SignatureException;
+import java.util.Map;
 
 public class PutBulk extends CliCommand<PutBulkResult> {
 
@@ -174,10 +173,13 @@ public class PutBulk extends CliCommand<PutBulkResult> {
 
         String resultMessage;
         if (this.pipe) {
-            job.transfer(new PipeFileObjectPutter(this.mapNormalizedObjectNameToObjectName));
+
+            final PipeFileObjectPutter pipeFileObjectPutter = new PipeFileObjectPutter(this.mapNormalizedObjectNameToObjectName);
+            job.withMetadata(pipeFileObjectPutter).transfer(pipeFileObjectPutter);
             resultMessage = String.format("SUCCESS: Wrote all piped files to bucket %s", this.bucketName);
         } else {
-            job.transfer(new PrefixedFileObjectPutter(this.inputDirectory, this.prefix));
+            final PrefixedFileObjectPutter prefixedFileObjectPutter = new PrefixedFileObjectPutter(this.inputDirectory, this.prefix);
+            job.withMetadata(prefixedFileObjectPutter).transfer(prefixedFileObjectPutter);
             resultMessage = String.format("SUCCESS: Wrote all the files in %s to bucket %s", this.inputDirectory.toString(), this.bucketName);
         }
 
@@ -275,33 +277,43 @@ public class PutBulk extends CliCommand<PutBulkResult> {
                 args.getPrefix()     != null;   //-p
     }
 
-    static class PrefixedFileObjectPutter implements Ds3ClientHelpers.ObjectChannelBuilder {
+    static class PrefixedFileObjectPutter implements Ds3ClientHelpers.ObjectChannelBuilder, Ds3ClientHelpers.MetadataAccess {
 
         final private LoggingFileObjectPutter objectPutter;
         final private String prefix;
+        final private Path inputDirectory;
 
         public PrefixedFileObjectPutter(final Path inputDirectory, final String prefix) {
             this.objectPutter = new LoggingFileObjectPutter(inputDirectory);
             this.prefix = prefix;
+            this.inputDirectory = inputDirectory;
         }
 
         @Override
-        public SeekableByteChannel buildChannel(final String s) throws IOException {
+        public SeekableByteChannel buildChannel(final String fileName) throws IOException {
+            final String objectName = removePrefix(fileName);
+            return this.objectPutter.buildChannel(objectName);
+        }
 
-            final String objectName;
+        @Override
+        public Map<String, String> getMetadataValue(final String fileName) {
+            final String unPrefixedFile = removePrefix(fileName);
 
+            final Path path = inputDirectory.resolve(unPrefixedFile);
+            return getMetadataValues(path);
+        }
+
+        private String removePrefix(final String fileName) {
             if (this.prefix == null) {
-                objectName = s;
+                return fileName;
             } else {
-                if (!s.startsWith(this.prefix)) {
-                    LOG.info("The object (" + s + ") does not begin with prefix " + this.prefix + ".  Ignoring adding the prefix.");
-                    objectName = s;
+                if (!fileName.startsWith(this.prefix)) {
+                    LOG.info("The object (" + fileName + ") does not begin with prefix " + this.prefix + ".  Ignoring adding the prefix.");
+                    return fileName;
                 } else {
-                    objectName = s.substring(this.prefix.length());
+                    return fileName.substring(this.prefix.length());
                 }
             }
-
-            return this.objectPutter.buildChannel(objectName);
         }
     }
 
@@ -359,7 +371,10 @@ public class PutBulk extends CliCommand<PutBulkResult> {
         }
     }
 
-    static class PipeFileObjectPutter implements Ds3ClientHelpers.ObjectChannelBuilder {
+    /**
+     * Returns a channel and metadata for files that have been piped in via stdin
+     */
+    static class PipeFileObjectPutter implements Ds3ClientHelpers.ObjectChannelBuilder, Ds3ClientHelpers.MetadataAccess {
 
         private final ImmutableMap<String, String> mapNormalizedObjectNameToObjectName;
 
@@ -371,6 +386,21 @@ public class PutBulk extends CliCommand<PutBulkResult> {
         public SeekableByteChannel buildChannel(final String s) throws IOException {
             return FileChannel.open(Paths.get(this.mapNormalizedObjectNameToObjectName.get(s)), StandardOpenOption.READ);
         }
+
+        @Override
+        public Map<String, String> getMetadataValue(final String s) {
+            final Path path = Paths.get(this.mapNormalizedObjectNameToObjectName.get(s));
+            return getMetadataValues(path);
+        }
     }
 
+    private static Map<String, String> getMetadataValues(final Path path) {
+        try {
+            final FileTime lastModifiedTime = Files.getLastModifiedTime(path);
+            return ImmutableMap.of("ds3-last-modified", Long.toString(lastModifiedTime.toMillis()));
+        } catch (final IOException e) {
+            LOG.error("Could not get the last modified time for file: " + path, e);
+            return null;
+        }
+    }
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutObject.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutObject.java
@@ -145,7 +145,12 @@ public class PutObject extends CliCommand<PutObjectResult> {
         }
 
         putJob.withMaxParallelRequests(this.numberOfThreads);
-        putJob.transfer(new Ds3ClientHelpers.ObjectChannelBuilder() {
+        putJob.withMetadata(new Ds3ClientHelpers.MetadataAccess() {
+            @Override
+            public Map<String, String> getMetadataValue(final String filename) {
+                return Utils.getMetadataValues(objectPath);
+            }
+        }).transfer(new Ds3ClientHelpers.ObjectChannelBuilder() {
             @Override
             public SeekableByteChannel buildChannel(final String s) throws IOException {
                 return FileChannel.open(objectPath, StandardOpenOption.READ);

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Constants.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Constants.java
@@ -1,0 +1,20 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3cli.util;
+
+class Constants {
+    static final String DS3_LAST_MODIFIED = "ds3-last-modified";
+}

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
@@ -17,7 +17,6 @@ package com.spectralogic.ds3cli.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.spectralogic.ds3cli.command.Constants;
 import com.spectralogic.ds3cli.command.PutBulk;
 import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.commands.spectrads3.GetSystemInformationSpectraS3Request;

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -574,6 +574,7 @@ public class Ds3Cli_Test {
         when(mockedFileUtils.isRegularFile(any(Path.class))).thenReturn(true);
         when(mockedFileUtils.size(any(Path.class))).thenReturn(100L);
         when(helpers.startWriteJob(eq("bucketName"), (Iterable<Ds3Object>) isNotNull())).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
 
         PowerMockito.mockStatic(BlackPearlUtils.class);
 
@@ -594,6 +595,7 @@ public class Ds3Cli_Test {
         final Iterable<Contents> retObj = Lists.newArrayList(c);
         when(helpers.listObjects(eq("bucketName"))).thenReturn(retObj);
         when(helpers.startWriteJob(eq("bucketName"), (Iterable<Ds3Object>) isNotNull())).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
 
         final FileUtils mockedFileUtils = mock(FileUtils.class);
         when(mockedFileUtils.exists(any(Path.class))).thenReturn(true);
@@ -658,6 +660,7 @@ public class Ds3Cli_Test {
         when(mockedFileUtils.isRegularFile(any(Path.class))).thenReturn(true);
         when(mockedFileUtils.size(any(Path.class))).thenReturn(100L);
         when(helpers.startWriteJob(eq("bucketName"), (Iterable<Ds3Object>) isNotNull())).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
 
         PowerMockito.mockStatic(BlackPearlUtils.class);
 
@@ -902,7 +905,7 @@ public class Ds3Cli_Test {
     public void putBulk() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName", "-d", "dir"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
-        final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
+        final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
         final FileUtils mockedFileUtils = mock(FileUtils.class);
 
         final Path p1 = Paths.get("obj1.txt");
@@ -910,9 +913,10 @@ public class Ds3Cli_Test {
         final ImmutableList<Path> retPath = ImmutableList.copyOf(Lists.newArrayList(p1, p2));
 
         final UUID jobId = UUID.randomUUID();
-        when(mockedGetJob.getJobId()).thenReturn(jobId);
+        when(mockedPutJob.getJobId()).thenReturn(jobId);
         final Iterable<Ds3Object> retObj = Lists.newArrayList(new Ds3Object("obj1.txt", 1245), new Ds3Object("obj2.txt", 12345));
-        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedGetJob);
+        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
 
         PowerMockito.mockStatic(Utils.class);
         when(Utils.getObjectsToPut((Iterable<Path>)isNotNull(), any(Path.class), any(Boolean.class))).thenCallRealMethod();
@@ -934,14 +938,15 @@ public class Ds3Cli_Test {
     public void putBulkWithSync() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName", "-d", "dir", "--sync"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
-        final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
+        final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
         final FileUtils mockedFileUtils = mock(FileUtils.class);
         final Iterable<Ds3Object> retObj = Lists.newArrayList(new Ds3Object("obj1.txt", 1245L), new Ds3Object("obj2.txt", 1245L));
 
         final UUID jobId = UUID.randomUUID();
-        when(mockedGetJob.getJobId()).thenReturn(jobId);
+        when(mockedPutJob.getJobId()).thenReturn(jobId);
         when(helpers.listObjectsForDirectory(any(Path.class))).thenReturn(retObj);
-        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedGetJob);
+        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
 
         final Contents c1 = new Contents();
         c1.setKey("obj1.txt");
@@ -1015,7 +1020,7 @@ public class Ds3Cli_Test {
 
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName", "-d", "dir", "--output-format", "json"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
-        final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
+        final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
         final FileUtils mockedFileUtils = mock(FileUtils.class);
         final Iterable<Ds3Object> retObj = Lists.newArrayList(new Ds3Object("obj1.txt", 1245), new Ds3Object("obj2.txt", 12345));
 
@@ -1032,8 +1037,9 @@ public class Ds3Cli_Test {
         when(Utils.getFileSize(eq(p2))).thenReturn(12345L);
 
         final UUID jobId = UUID.randomUUID();
-        when(mockedGetJob.getJobId()).thenReturn(jobId);
-        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedGetJob);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
+        when(mockedPutJob.getJobId()).thenReturn(jobId);
+        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
 
         PowerMockito.mockStatic(BlackPearlUtils.class);
 
@@ -1159,7 +1165,7 @@ public class Ds3Cli_Test {
     public void putBulkWithIgnoreErrors() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName", "-d", "dir", "--ignore-errors"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
-        final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
+        final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
         final FileUtils mockedFileUtils = mock(FileUtils.class);
 
         PowerMockito.mockStatic(BlackPearlUtils.class);
@@ -1170,13 +1176,14 @@ public class Ds3Cli_Test {
         final ImmutableList<Path> retPath = ImmutableList.copyOf(Lists.newArrayList(p1, p2, p3));
 
         final UUID jobId = UUID.randomUUID();
-        when(mockedGetJob.getJobId()).thenReturn(jobId);
+        when(mockedPutJob.getJobId()).thenReturn(jobId);
         final Iterable<Ds3Object> retObj = Lists.newArrayList(
                 new Ds3Object("obj1.txt", 1245),
                 new Ds3Object("obj2.txt", 12345));
-        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedGetJob);
+        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
 
         PowerMockito.mockStatic(Utils.class);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
         when(Utils.getObjectsToPut((Iterable<Path>)isNotNull(), any(Path.class), any(Boolean.class))).thenCallRealMethod();
         when(Utils.listObjectsForDirectory(any(Path.class))).thenReturn(retPath);
         when(Utils.getFileName(any(Path.class), eq(p1))).thenReturn("obj1.txt");
@@ -1204,7 +1211,7 @@ public class Ds3Cli_Test {
     public void putBulkWithIgnoreErrorsJson() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName", "-d", "dir", "--ignore-errors", "--output-format", "json"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
-        final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
+        final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
         final FileUtils mockedFileUtils = mock(FileUtils.class);
 
         PowerMockito.mockStatic(BlackPearlUtils.class);
@@ -1215,13 +1222,14 @@ public class Ds3Cli_Test {
         final ImmutableList<Path> retPath = ImmutableList.copyOf(Lists.newArrayList(p1, p2, p3));
 
         final UUID jobId = UUID.randomUUID();
-        when(mockedGetJob.getJobId()).thenReturn(jobId);
+        when(mockedPutJob.getJobId()).thenReturn(jobId);
         final Iterable<Ds3Object> retObj = Lists.newArrayList(
                 new Ds3Object("obj1.txt", 1245),
                 new Ds3Object("obj2.txt", 12345));
-        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedGetJob);
+        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
 
         PowerMockito.mockStatic(Utils.class);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
         when(Utils.getObjectsToPut((Iterable<Path>)isNotNull(), any(Path.class), any(Boolean.class))).thenCallRealMethod();
         when(Utils.listObjectsForDirectory(any(Path.class))).thenReturn(retPath);
         when(Utils.getFileName(any(Path.class), eq(p1))).thenReturn("obj1.txt");
@@ -1258,13 +1266,13 @@ public class Ds3Cli_Test {
     public void putBulkWithPipe() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
-        final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
+        final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
         final FileUtils mockedFileUtils = mock(FileUtils.class);
 
         final UUID jobId = UUID.randomUUID();
-        when(mockedGetJob.getJobId()).thenReturn(jobId);
+        when(mockedPutJob.getJobId()).thenReturn(jobId);
         final Iterable<Ds3Object> retObj = Lists.newArrayList(new Ds3Object("obj1.txt", 1245), new Ds3Object("obj2.txt", 12345));
-        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedGetJob);
+        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
 
         final Path p1 = Paths.get("obj1.txt");
         final Path p2 = Paths.get("obj2.txt");
@@ -1279,6 +1287,7 @@ public class Ds3Cli_Test {
             }
         });
         when(Utils.isPipe()).thenReturn(true);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
         when(Utils.getPipedFilesFromStdin(any(FileUtils.class))).thenReturn(retPath);
         when(Utils.getObjectsToPut((Iterable<Path>) isNotNull(), any(Path.class), any(Boolean.class))).thenCallRealMethod();
         when(Utils.getFileName(any(Path.class), eq(p1))).thenReturn(p1.toString());
@@ -1298,13 +1307,13 @@ public class Ds3Cli_Test {
     public void putBulkWithPipeAndSync() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName", "--sync"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
-        final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
+        final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
         final FileUtils mockedFileUtils = mock(FileUtils.class);
 
         final UUID jobId = UUID.randomUUID();
-        when(mockedGetJob.getJobId()).thenReturn(jobId);
+        when(mockedPutJob.getJobId()).thenReturn(jobId);
         final Iterable<Ds3Object> retObj = Lists.newArrayList(new Ds3Object("obj1.txt", 1245), new Ds3Object("obj2.txt", 12345));
-        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedGetJob);
+        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
 
         final Iterable<Contents> retCont = Lists.newArrayList();
         when(helpers.listObjects(eq("bucketName"), any(String.class))).thenReturn(retCont);
@@ -1321,6 +1330,8 @@ public class Ds3Cli_Test {
                 return (String) args[0];
             }
         });
+
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
         when(Utils.isPipe()).thenReturn(true);
         when(Utils.getPipedFilesFromStdin(any(FileUtils.class))).thenReturn(retPath);
         when(Utils.getObjectsToPut((Iterable<Path>)isNotNull(), any(Path.class), any(Boolean.class))).thenCallRealMethod();


### PR DESCRIPTION
This commit adds basic support for storing and restoring the last modified field.  Need to add this logic to the singular get/put object commands.