### PR TITLE
Add "Eject Label" and "Eject Location" fields to standard CLI output …

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/views/cli/GetPhysicalPlacementWithFullDetailsView.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/views/cli/GetPhysicalPlacementWithFullDetailsView.java
@@ -127,11 +127,14 @@ public class GetPhysicalPlacementWithFullDetailsView  implements View<GetPhysica
 
         for (int i = 0; i < tapesList.size(); i ++) {
             final Tape tape = tapesList.get(i);
-            final String[] tapePlacementArray = new String[4];
+            final String[] tapePlacementArray = new String[6];
             tapePlacementArray[0] = nullGuard(tape.getBarCode());
             tapePlacementArray[1] = nullGuard(tape.getState().toString());
             tapePlacementArray[2] = nullGuard(tape.getType().toString());
             tapePlacementArray[3] = nullGuard(tape.getDescriptionForIdentification());
+            tapePlacementArray[4] = nullGuard(tape.getEjectLabel());
+            tapePlacementArray[5] = nullGuard(tape.getEjectLocation());
+
             formatArray[i] = tapePlacementArray;
         }
 
@@ -143,7 +146,9 @@ public class GetPhysicalPlacementWithFullDetailsView  implements View<GetPhysica
                 new ASCIITableHeader("Tape Bar Code", ASCIITable.ALIGN_LEFT),
                 new ASCIITableHeader("State", ASCIITable.ALIGN_LEFT),
                 new ASCIITableHeader("Type", ASCIITable.ALIGN_LEFT),
-                new ASCIITableHeader("Description", ASCIITable.ALIGN_LEFT)
+                new ASCIITableHeader("Description", ASCIITable.ALIGN_LEFT),
+                new ASCIITableHeader("Eject Label", ASCIITable.ALIGN_LEFT),
+                new ASCIITableHeader("Eject Location", ASCIITable.ALIGN_LEFT)
         };
     }
 }

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -1422,6 +1422,8 @@ public class Ds3Cli_Test {
         tape1.setTotalRawCapacity(20000L);
         tape1.setType(TapeType.LTO6);
         tape1.setWriteProtected(false);
+        tape1.setEjectLabel("Tape1EjectLabel");
+        tape1.setEjectLocation("Tape1EjectLocation");
 
         final Tape tape2 = new Tape();
         tape2.setAssignedToStorageDomain(false);
@@ -1439,6 +1441,8 @@ public class Ds3Cli_Test {
         tape2.setTotalRawCapacity(20000L);
         tape2.setType(TapeType.LTO7);
         tape2.setWriteProtected(false);
+        tape2.setEjectLabel("Tape2EjectLabel");
+        tape2.setEjectLocation("Tape2EjectLocation");
 
         final BulkObject testObject = new BulkObject();
         testObject.setName("testObject");
@@ -1471,9 +1475,9 @@ public class Ds3Cli_Test {
         assertTrue(result.getMessage().contains("| Object Name | ID | In Cache | Length | Offset | Latest | Version |"));
         assertTrue(result.getMessage().contains("| testObject  |    | Unknown  | 1024   | 0      | false  | 0       |"));
 
-        assertTrue(result.getMessage().contains("| Tape Bar Code |        State       | Type | Description |"));
-        assertTrue(result.getMessage().contains("| 121557L6      | PENDING_INSPECTION | LTO6 | N/A         |"));
-        assertTrue(result.getMessage().contains("| 421555L7      | PENDING_INSPECTION | LTO7 | N/A         |"));
+        assertTrue(result.getMessage().contains("| Tape Bar Code |        State       | Type | Description |   Eject Label   |   Eject Location   |"));
+        assertTrue(result.getMessage().contains("| 121557L6      | PENDING_INSPECTION | LTO6 | N/A         | Tape1EjectLabel | Tape1EjectLocation |"));
+        assertTrue(result.getMessage().contains("| 421555L7      | PENDING_INSPECTION | LTO7 | N/A         | Tape2EjectLabel | Tape2EjectLocation |"));
 
         assertThat(result.getReturnCode(), is(0));
     }


### PR DESCRIPTION
…for "GetPhysicalPlacement" tape table.

+-------------+----+----------+--------+--------+--------+---------+
| Object Name | ID | In Cache | Length | Offset | Latest | Version |
+-------------+----+----------+--------+--------+--------+---------+
| testObject  |    | Unknown  | 1024   | 0      | false  | 0       |
+-------------+----+----------+--------+--------+--------+---------+
+---------------+--------------------+------+-------------+-----------------+--------------------+
| Tape Bar Code |        State       | Type | Description |   Eject Label   |   Eject Location   |
+---------------+--------------------+------+-------------+-----------------+--------------------+
| 121557L6      | PENDING_INSPECTION | LTO6 | N/A         | Tape1EjectLabel | Tape1EjectLocation |
| 421555L7      | PENDING_INSPECTION | LTO7 | N/A         | Tape2EjectLabel | Tape2EjectLocation |
+---------------+--------------------+------+-------------+-----------------+--------------------+
