### PR TITLE
Fix get_tapes command (JAVACLI-68); new build obviates JAVACLI-62

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Ds3Cli.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Ds3Cli.java
@@ -74,7 +74,7 @@ public class Ds3Cli implements Callable<CommandResponse> {
         cliViews.put(CommandValue.GET_JOB,                new com.spectralogic.ds3cli.views.cli.GetJobView());
         cliViews.put(CommandValue.DELETE_FOLDER,          deleteView);
         cliViews.put(CommandValue.PUT_JOB,                new com.spectralogic.ds3cli.views.cli.PutJobView());
-        cliViews.put(CommandValue.GET_TAPES,              new com.spectralogic.ds3cli.views.cli.GetTapesWithFullDetailsView());
+        cliViews.put(CommandValue.GET_TAPES,              new com.spectralogic.ds3cli.views.cli.GetTapesView());
         cliViews.put(CommandValue.DELETE_TAPE,            deleteView);
         cliViews.put(CommandValue.PERFORMANCE,            new com.spectralogic.ds3cli.views.cli.PerformanceView());
         cliViews.put(CommandValue.GET_PHYSICAL_PLACEMENT, new com.spectralogic.ds3cli.views.cli.GetPhysicalPlacementWithFullDetailsView());
@@ -104,7 +104,7 @@ public class Ds3Cli implements Callable<CommandResponse> {
         jsonViews.put(CommandValue.GET_JOB,                new com.spectralogic.ds3cli.views.json.GetJobView());
         jsonViews.put(CommandValue.DELETE_FOLDER,          deleteView);
         jsonViews.put(CommandValue.PUT_JOB,                new com.spectralogic.ds3cli.views.json.PutJobView());
-        jsonViews.put(CommandValue.GET_TAPES,              new com.spectralogic.ds3cli.views.json.GetTapesWithFullDetailsView());
+        jsonViews.put(CommandValue.GET_TAPES,              new com.spectralogic.ds3cli.views.json.GetTapesView());
         jsonViews.put(CommandValue.DELETE_TAPE,            deleteView);
         jsonViews.put(CommandValue.GET_PHYSICAL_PLACEMENT, new com.spectralogic.ds3cli.views.json.GetPhysicalPlacementWithFullDetailsView());
         jsonViews.put(CommandValue.GET_TAPE_FAILURE,       new com.spectralogic.ds3cli.views.json.GetTapeFailureView());

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetTapes.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetTapes.java
@@ -17,14 +17,15 @@ package com.spectralogic.ds3cli.command;
 
 import com.spectralogic.ds3cli.Arguments;
 import com.spectralogic.ds3cli.exceptions.CommandException;
-import com.spectralogic.ds3cli.models.GetTapesWithFullDetailsResult;
+import com.spectralogic.ds3cli.models.GetTapesResult;
 import com.spectralogic.ds3cli.util.Ds3Provider;
 import com.spectralogic.ds3cli.util.FileUtils;
-import com.spectralogic.ds3client.commands.spectrads3.GetTapesWithFullDetailsSpectraS3Request;
-import com.spectralogic.ds3client.commands.spectrads3.GetTapesWithFullDetailsSpectraS3Response;
+import com.spectralogic.ds3client.commands.spectrads3.GetTapesSpectraS3Request;
+import com.spectralogic.ds3client.commands.spectrads3.GetTapesSpectraS3Response;
+import com.spectralogic.ds3client.models.Tape;
 import com.spectralogic.ds3client.networking.FailedRequestException;
 
-public class GetTapes extends CliCommand<GetTapesWithFullDetailsResult> {
+public class GetTapes extends CliCommand<GetTapesResult> {
     public GetTapes(final Ds3Provider ds3Provider, final FileUtils fileUtils) {
         super(ds3Provider, fileUtils);
     }
@@ -35,10 +36,10 @@ public class GetTapes extends CliCommand<GetTapesWithFullDetailsResult> {
     }
 
     @Override
-    public GetTapesWithFullDetailsResult call() throws Exception {try {
-            final GetTapesWithFullDetailsSpectraS3Response response = getClient().getTapesWithFullDetailsSpectraS3(new GetTapesWithFullDetailsSpectraS3Request());
+    public GetTapesResult call() throws Exception {try {
+            final GetTapesSpectraS3Response response = getClient().getTapesSpectraS3(new GetTapesSpectraS3Request());
 
-            return new GetTapesWithFullDetailsResult(response.getNamedDetailedTapeListResult());
+            return new GetTapesResult(response.getTapeListResult());
         } catch (final FailedRequestException e) {
             throw new CommandException("Failed Get Tapes", e);
         }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/models/GetTapesResult.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/models/GetTapesResult.java
@@ -1,0 +1,32 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3cli.models;
+
+import com.spectralogic.ds3client.models.TapeList;
+
+public class GetTapesResult implements Result {
+
+    private TapeList tapeListResult;
+
+    public GetTapesResult(final TapeList tapes) {
+        this.tapeListResult = tapes;
+    }
+
+    public TapeList getTapeList() {
+        return tapeListResult;
+    }
+}
+

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
@@ -92,6 +92,13 @@ public final class Utils {
         return message;
     }
 
+    public static String nullGuardToString(final Object o) {
+        if (o == null) {
+            return "N/A";
+        }
+        return o.toString();
+    }
+
     public static ObjectsToPut getObjectsToPut(final Iterable<Path> filteredObjects, final Path inputDirectory, final boolean ignoreErrors) throws IOException {
         final ImmutableList.Builder<Ds3Object> objectsBuilder = ImmutableList.builder();
         final ImmutableList.Builder<PutBulk.IgnoreFile> ignoredBuilder = ImmutableList.builder();

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/views/cli/GetTapesView.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/views/cli/GetTapesView.java
@@ -1,0 +1,75 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3cli.views.cli;
+
+import com.bethecoder.ascii_table.ASCIITable;
+import com.bethecoder.ascii_table.ASCIITableHeader;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.spectralogic.ds3cli.View;
+import com.spectralogic.ds3cli.models.GetTapesResult;
+import com.spectralogic.ds3cli.models.GetTapesWithFullDetailsResult;
+import com.spectralogic.ds3client.models.NamedDetailedTape;
+import com.spectralogic.ds3client.models.NamedDetailedTapeList;
+import com.spectralogic.ds3client.models.Tape;
+import com.spectralogic.ds3client.models.TapeList;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.TimeZone;
+
+import static com.spectralogic.ds3cli.util.Utils.nullGuard;
+import static com.spectralogic.ds3cli.util.Utils.nullGuardToString;
+
+public class GetTapesView implements View<GetTapesResult> {
+    @Override
+    public String render(final GetTapesResult obj) throws JsonProcessingException {
+        if (obj != null) {
+            final TapeList tapeList = obj.getTapeList();
+            if ((tapeList != null) || (null != tapeList.getTapes())) {
+                return ASCIITable.getInstance().getTable(getHeaders(), formatTapeList(tapeList));
+            }
+        }
+        return "You do not have any tapes";
+    }
+
+    private String[][] formatTapeList(final TapeList tapeList) {
+        final List<Tape> tapes = tapeList.getTapes();
+        final String [][] formatArray = new String[tapes.size()][];
+
+        int i = 0;
+        for (final Tape tape : tapes ) {
+            final String [] bucketArray = new String[5];
+            bucketArray[0] = nullGuardToString(tape.getBarCode());
+            bucketArray[1] = nullGuardToString(tape.getId());
+            bucketArray[2] = nullGuardToString(tape.getState());
+            bucketArray[3] = nullGuardToString(tape.getLastModified());
+            bucketArray[4] = nullGuardToString(tape.getAvailableRawCapacity());
+            formatArray[i++] = bucketArray;
+        }
+        return formatArray;
+    }
+
+    private ASCIITableHeader[] getHeaders() {
+        return new ASCIITableHeader[]{
+                new ASCIITableHeader("Bar Code", ASCIITable.ALIGN_LEFT),
+                new ASCIITableHeader("ID", ASCIITable.ALIGN_LEFT),
+                new ASCIITableHeader("State", ASCIITable.ALIGN_LEFT),
+                new ASCIITableHeader("Last Modified", ASCIITable.ALIGN_LEFT),
+                new ASCIITableHeader("Available Raw Capacity", ASCIITable.ALIGN_LEFT)
+        };
+    }
+}
+

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/views/json/GetTapesView.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/views/json/GetTapesView.java
@@ -1,0 +1,40 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.spectralogic.ds3cli.views.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.spectralogic.ds3cli.View;
+import com.spectralogic.ds3cli.models.GetTapesResult;
+import com.spectralogic.ds3cli.models.GetTapesWithFullDetailsResult;
+import com.spectralogic.ds3cli.util.JsonMapper;
+import com.spectralogic.ds3client.models.NamedDetailedTapeList;
+import com.spectralogic.ds3client.models.TapeList;
+
+public class GetTapesView implements View<GetTapesResult> {
+    @Override
+    public String render(final GetTapesResult obj) throws JsonProcessingException {
+        final TapeList result = obj.getTapeList();
+        final CommonJsonView view = CommonJsonView.newView(CommonJsonView.Status.OK);
+
+        if ((result == null) || (null == result.getTapes())) {
+            view.message("You do not have any tapes");
+            return JsonMapper.toJson(view);
+        }
+
+        return JsonMapper.toJson(view.data(result));
+    }
+}
+


### PR DESCRIPTION
Was returning NamedDetailedTape and tries to parse as Tape