### PR TITLE
Add --discard option for get_bulk to simulate /dev/null (JAVACLI-75)

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
@@ -60,6 +60,7 @@ public class Arguments {
     private boolean sync = false;
     private String numberOfFiles;
     private String sizeOfFiles;
+    private boolean discard = false;
     private ViewType outputFormat = ViewType.CLI;
 
     private String version = "N/a";
@@ -152,6 +153,8 @@ public class Arguments {
                 .hasArgs()
                 .withValueSeparator(',')
                 .create();
+        final Option discard = new Option(null, false, "Discard restoration data (/dev/null)");
+        discard.setLongOpt("discard");
 
         this.options.addOption(ds3Endpoint);
         this.options.addOption(bucket);
@@ -187,7 +190,7 @@ public class Arguments {
         this.options.addOption(followSymLinks);
         this.options.addOption(metadata);
         this.options.addOption(modifyParams);
-
+        this.options.addOption(discard);
         this.processCommandLine();
     }
 
@@ -364,6 +367,10 @@ public class Arguments {
         }
         if (cmd.hasOption("modify-params")) {
             this.setModifyParams(Metadata.parse(cmd.getOptionValues("modify-params")));
+        }
+
+        if (cmd.hasOption("discard")) {
+            this.setDiscard(true);
         }
     }
 
@@ -651,4 +658,13 @@ public class Arguments {
     }
 
     void setModifyParams(final ImmutableMap<String, String> modifyParams) { this.modifyParams = modifyParams; }
+
+    public boolean isDiscard() {
+        return discard;
+    }
+
+    void setDiscard(final boolean discard) {
+        this.discard = discard;
+    }
+
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
@@ -153,7 +153,7 @@ public class Arguments {
                 .hasArgs()
                 .withValueSeparator(',')
                 .create();
-        final Option discard = new Option(null, false, "Discard restoration data (/dev/null)");
+        final Option discard = new Option(null, false, "Discard restoration data (/dev/null) in get_bulk");
         discard.setLongOpt("discard");
 
         this.options.addOption(ds3Endpoint);

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
@@ -51,6 +51,9 @@ public class GetBulk extends CliCommand<GetBulkResult> {
 
     private final static Logger LOG = LoggerFactory.getLogger(GetBulk.class);
 
+    private final static int DEFAULT_BUFFER_SIZE = 1024 * 1024;
+    private final static long DEFAULT_FILE_SIZE = 1024L;
+
     private String bucketName;
     private Path outputPath;
     private String prefix;
@@ -59,7 +62,6 @@ public class GetBulk extends CliCommand<GetBulkResult> {
     private boolean sync;
     private boolean force;
     private boolean discard;
-    private int bufferSize;
     private int numberOfThreads;
 
     public GetBulk(final Ds3Provider provider, final FileUtils fileUtils) {
@@ -90,7 +92,6 @@ public class GetBulk extends CliCommand<GetBulkResult> {
             if (directory != null) {
                 throw new CommandException("Cannot set both directoy and --discard");
             }
-            bufferSize = Integer.valueOf(args.getBufferSize());
         }
 
         this.priority = args.getPriority();
@@ -118,7 +119,7 @@ public class GetBulk extends CliCommand<GetBulkResult> {
 //            getter = new VerifyingFileObjectGetter(this.outputPath);
         } else if (this.discard) {
             LOG.warn("Using /dev/null getter -- all incoming data will be discarded");
-            getter = new MemoryObjectChannelBuilder(this.bufferSize, 1024L);
+            getter = new MemoryObjectChannelBuilder(DEFAULT_BUFFER_SIZE, DEFAULT_FILE_SIZE);
         } else {
             getter = new FileObjectGetter(this.outputPath);
         }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PerformanceCommand.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PerformanceCommand.java
@@ -7,6 +7,7 @@ import com.spectralogic.ds3cli.exceptions.CommandException;
 import com.spectralogic.ds3cli.models.PerformanceResult;
 import com.spectralogic.ds3cli.util.Ds3Provider;
 import com.spectralogic.ds3cli.util.FileUtils;
+import com.spectralogic.ds3cli.util.MemoryObjectChannelBuilder;
 import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.commands.DeleteBucketRequest;
 import com.spectralogic.ds3client.commands.DeleteObjectRequest;
@@ -139,21 +140,6 @@ public class PerformanceCommand extends CliCommand<PerformanceResult> {
         client.deleteBucket(new DeleteBucketRequest(bucketName));
     }
 
-    private class MemoryObjectChannelBuilder implements Ds3ClientHelpers.ObjectChannelBuilder {
-        private final int bufferSize;
-        private final long sizeOfFiles;
-
-        public MemoryObjectChannelBuilder(final int bufferSize, final long sizeOfFile) {
-            this.bufferSize = bufferSize;
-            this.sizeOfFiles = sizeOfFile;
-        }
-
-        @Override
-        public SeekableByteChannel buildChannel(final String key) throws IOException {
-            return new PerformanceSeekableByteChannel(this.bufferSize, this.sizeOfFiles);
-        }
-    }
-
     private class PerformanceListener implements DataTransferredListener, ObjectCompletedListener {
         private final long startTime;
         private final int totalNumberOfFiles;
@@ -210,63 +196,6 @@ public class PerformanceCommand extends CliCommand<PerformanceResult> {
         }
     }
 
-    private class PerformanceSeekableByteChannel implements SeekableByteChannel {
-        final private int bufferSize;
-        final private byte[] backingArray;
-        final private long limit;
-        private int position;
-        private boolean isOpen;
-
-        public PerformanceSeekableByteChannel(final int bufferSize, final long size) {
-            this.bufferSize = bufferSize;
-            final byte[] bytes = new byte[bufferSize];
-            for (int i = 0; i < bufferSize; i++) {
-                bytes[i] = '1';
-            }
-            backingArray = bytes;
-
-            this.position = 0;
-            this.limit = size * 1024L * 1024L;
-            this.isOpen = true;
-        }
-
-        public boolean isOpen() {
-            return this.isOpen;
-        }
-
-        public void close() throws IOException {
-            this.isOpen = false;
-        }
-
-        public int read(final ByteBuffer dst) throws IOException {
-            final int amountToRead = Math.min(dst.remaining(), this.bufferSize);
-            dst.put(this.backingArray, 0, amountToRead);
-            return amountToRead;
-        }
-
-        public int write(final ByteBuffer src) throws IOException {
-            final int amountToWrite = Math.min(src.remaining(), this.bufferSize);
-            src.get(this.backingArray, 0, amountToWrite);
-            return amountToWrite;
-        }
-
-        public long position() throws IOException {
-            return (long) this.position;
-        }
-
-        public SeekableByteChannel position(final long newPosition) throws IOException {
-            this.position = (int) newPosition;
-            return this;
-        }
-
-        public long size() throws IOException {
-            return this.limit;
-        }
-
-        public SeekableByteChannel truncate(final long size) throws IOException {
-            return this;
-        }
-    }
 }
 
 

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/MemoryObjectChannelBuilder.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/MemoryObjectChannelBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+package com.spectralogic.ds3cli.util;
+
+import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+
+/**
+ * THIS CLASS DISCARDS ALL INCOMING RESTORE DATA!
+ * Good for testing, bad for general customer applciations.
+ *
+ * Reading from this provides all 1's
+ */
+public class MemoryObjectChannelBuilder implements Ds3ClientHelpers.ObjectChannelBuilder {
+    private final int bufferSize;
+    private final long sizeOfFiles;
+
+    public MemoryObjectChannelBuilder(final int bufferSize, final long sizeOfFile) {
+        this.bufferSize = bufferSize;
+        this.sizeOfFiles = sizeOfFile;
+    }
+
+    @Override
+    public SeekableByteChannel buildChannel(final String key) throws IOException {
+        return new DevNullByteChannel(this.bufferSize, this.sizeOfFiles);
+    }
+
+    private class DevNullByteChannel implements SeekableByteChannel {
+        final private int bufferSize;
+        final private byte[] backingArray;
+        final private long limit;
+        private int position;
+        private boolean isOpen;
+
+        public DevNullByteChannel(final int bufferSize, final long size) {
+            this.bufferSize = bufferSize;
+            final byte[] bytes = new byte[bufferSize];
+            for (int i = 0; i < bufferSize; i++) {
+                bytes[i] = '1';
+            }
+            backingArray = bytes;
+
+            this.position = 0;
+            this.limit = size * 1024L * 1024L;
+            this.isOpen = true;
+        }
+
+        public boolean isOpen() {
+            return this.isOpen;
+        }
+
+        public void close() throws IOException {
+            this.isOpen = false;
+        }
+
+        public int read(final ByteBuffer dst) throws IOException {
+            final int amountToRead = Math.min(dst.remaining(), this.bufferSize);
+            dst.put(this.backingArray, 0, amountToRead);
+            return amountToRead;
+        }
+
+        public int write(final ByteBuffer src) throws IOException {
+            final int amountToWrite = Math.min(src.remaining(), this.bufferSize);
+            src.get(this.backingArray, 0, amountToWrite);
+            return amountToWrite;
+        }
+
+        public long position() throws IOException {
+            return (long) this.position;
+        }
+
+        public SeekableByteChannel position(final long newPosition) throws IOException {
+            this.position = (int) newPosition;
+            return this;
+        }
+
+        public long size() throws IOException {
+            return this.limit;
+        }
+
+        public SeekableByteChannel truncate(final long size) throws IOException {
+            return this;
+        }
+    }
+}

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -839,6 +839,26 @@ public class Ds3Cli_Test {
     }
 
     @Test
+    public void getBulkWithBadArgs() throws Exception {
+        final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "get_bulk", "-b", "bucketName", "-d", "targetdir", "--discard"});
+        final String expected = "Cannot set both directoy and --discard";
+
+        final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
+        final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
+        final FileUtils mockedFileUtils = mock(FileUtils.class);
+
+        when(helpers.startReadAllJob(eq("bucketName"), any(ReadJobOptions.class))).thenReturn(mockedGetJob);
+
+        PowerMockito.mockStatic(BlackPearlUtils.class);
+
+        final Ds3Cli cli = new Ds3Cli(new Ds3ProviderImpl(null, helpers), args, mockedFileUtils);
+        final CommandResponse result = cli.call();
+        assertThat(result.getMessage(), is(expected));
+        assertThat(result.getReturnCode(), is(1));
+    }
+
+
+    @Test
     public void getBulkWithSync() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "get_bulk", "-b", "bucketName", "--sync"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);


### PR DESCRIPTION
Moved MemoryObjectChannelBuilder out of PerformanceCommand.java to its own class to facilitate sharing.