### PR TITLE
Javacli79

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
@@ -72,10 +72,10 @@ public class Arguments {
     private Level consoleLogLevel;
     private Level fileLogLevel;
 
-    // don't use Logger because teh user's [refebrnces are not yet set
+    // don't use Logger because the user's preferences are not yet set
     // collect log info that will be logged by Main
     private static StringBuilder argumentLog = new StringBuilder("Argument processing");
-    private void addToLog(String logItem) { argumentLog.append(" | " + logItem) ; }
+    private void addToLog(final String logItem) { argumentLog.append(" | " + logItem) ; }
     public String getArgumentLog() { return argumentLog.toString(); }
 
     public Arguments(final String[] args) throws BadArgumentException, ParseException {

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
@@ -31,27 +31,32 @@ import org.slf4j.LoggerFactory;
 public class Main {
     private final static ch.qos.logback.classic.Logger LOG = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Main.class);
 
+    private static void configureLogging(final String consoleLevel, final String fileLevel) {
+        // turn root log wide open, filters will be set to argument levels
+        LOG.setLevel(Level.ALL);
+
+        final Appender fileAppender =  LOG.getAppender("LOGFILE");
+        final ch.qos.logback.classic.filter.ThresholdFilter fileFilter = new ThresholdFilter();
+        fileFilter.setLevel(consoleLevel);
+        fileFilter.setName(consoleLevel);
+        fileAppender.addFilter(fileFilter);
+        fileFilter.start();
+
+        final Appender consoleAppender =  LOG.getAppender("STDOUT");
+        final ch.qos.logback.classic.filter.ThresholdFilter consoleFilter = new ThresholdFilter();
+        consoleFilter.setLevel(fileLevel);
+        consoleFilter.setName(fileLevel);
+        consoleAppender.addFilter(consoleFilter);
+        consoleFilter.start();
+    }
+
     public static void main(final String[] args) {
 
         try {
             final Arguments arguments = new Arguments(args);
 
             // turn root log wide open, filters will be set to argument levels
-            LOG.setLevel(Level.ALL);
-
-            final Appender fileAppender =  LOG.getAppender("LOGFILE");
-            final ch.qos.logback.classic.filter.ThresholdFilter fileFilter = new ThresholdFilter();
-            fileFilter.setLevel(arguments.getFileLogLevel().toString());
-            fileFilter.setName(arguments.getFileLogLevel().toString());
-            fileAppender.addFilter(fileFilter);
-            fileFilter.start();
-
-            final Appender consoleAppender =  LOG.getAppender("STDOUT");
-            final ch.qos.logback.classic.filter.ThresholdFilter consoleFilter = new ThresholdFilter();
-            consoleFilter.setLevel(arguments.getConsoleLogLevel().toString());
-            consoleFilter.setName(arguments.getConsoleLogLevel().toString());
-            consoleAppender.addFilter(consoleFilter);
-            consoleFilter.start();
+            configureLogging(arguments.getFileLogLevel().toString(), arguments.getConsoleLogLevel().toString());
 
             LOG.info("Version: " + arguments.getVersion());
             LOG.info("Console log level: " + arguments.getConsoleLogLevel().toString());

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
@@ -15,6 +15,9 @@
 
 package com.spectralogic.ds3cli;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.filter.ThresholdFilter;
+import ch.qos.logback.core.Appender;
 import com.spectralogic.ds3cli.util.Ds3Provider;
 import com.spectralogic.ds3cli.util.FileUtils;
 import com.spectralogic.ds3cli.util.Utils;
@@ -23,16 +26,37 @@ import com.spectralogic.ds3client.Ds3ClientBuilder;
 import com.spectralogic.ds3client.models.common.Credentials;
 import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
 import com.spectralogic.ds3client.networking.FailedRequestException;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Main {
-
-    private final static Logger LOG = LoggerFactory.getLogger(Main.class);
+    private final static ch.qos.logback.classic.Logger LOG = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Main.class);
 
     public static void main(final String[] args) {
+
         try {
             final Arguments arguments = new Arguments(args);
+
+            // turn root log wide open, filters will be set to argument levels
+            LOG.setLevel(Level.ALL);
+
+            final Appender fileAppender =  LOG.getAppender("LOGFILE");
+            final ch.qos.logback.classic.filter.ThresholdFilter fileFilter = new ThresholdFilter();
+            fileFilter.setLevel(arguments.getFileLogLevel().toString());
+            fileFilter.setName(arguments.getFileLogLevel().toString());
+            fileAppender.addFilter(fileFilter);
+            fileFilter.start();
+
+            final Appender consoleAppender =  LOG.getAppender("STDOUT");
+            final ch.qos.logback.classic.filter.ThresholdFilter consoleFilter = new ThresholdFilter();
+            consoleFilter.setLevel(arguments.getConsoleLogLevel().toString());
+            consoleFilter.setName(arguments.getConsoleLogLevel().toString());
+            consoleAppender.addFilter(consoleFilter);
+            consoleFilter.start();
+
+            LOG.info("Version: " + arguments.getVersion());
+            LOG.info("Console log level: " + arguments.getConsoleLogLevel().toString());
+            LOG.info("Log file log level: " + arguments.getFileLogLevel().toString());
+            LOG.info(arguments.getArgumentLog());
 
             if (arguments.isHelp()) {
                 // no need to connect to vend help
@@ -50,8 +74,6 @@ public class Main {
 
             final Ds3Provider provider = new Ds3ProviderImpl(client, Ds3ClientHelpers.wrap(client));
             final FileUtils fileUtils = new FileUtilsImpl();
-
-
 
             final Ds3Cli runner = new Ds3Cli(provider, arguments, fileUtils);
             final CommandResponse response = runner.call();

--- a/ds3_java_cli/src/main/resources/logback-test.xml
+++ b/ds3_java_cli/src/main/resources/logback-test.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+
+    <property name="CLI_HOME" value="./ds3logs" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ALL</level>
+            <name>all</name>
+        </filter>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} +++ %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOGFILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ALL</level>
+            <name>all</name>
+        </filter>
+        <file>${CLI_HOME}/spectra.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${CLI_HOME}/spectra.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- keep 30 days' worth of history capped at 3GB total size -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss} +++ %msg%n
+            </Pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.spectralogic.ds3cli.Main" level="off"
+            additivity="false">
+        <level value="ALL" />
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="LOGFILE" />
+    </logger>
+
+    <root level="ALL">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="LOGFILE" />
+    </root>
+</configuration>

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -187,7 +187,7 @@ public class Ds3Cli_Test {
 
         final Ds3Cli cli = new Ds3Cli(new Ds3ProviderImpl(client, null), args, null);
         final CommandResponse result = cli.call();
-        assertThat(result.getMessage(), is("Failed Get Service"));
+        assertThat(result.getMessage(), is("Failed Get Service\n"));
         assertThat(result.getReturnCode(), is(1));
     }
 
@@ -839,7 +839,7 @@ public class Ds3Cli_Test {
     @Test
     public void getBulkWithBadArgs() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "get_bulk", "-b", "bucketName", "-d", "targetdir", "--discard"});
-        final String expected = "Cannot set both directory and --discard";
+        final String expected = "Cannot set both directory and --discard\n";
 
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
         final Ds3ClientHelpers.Job mockedGetJob = mock(Ds3ClientHelpers.Job.class);
@@ -1715,7 +1715,7 @@ public class Ds3Cli_Test {
     @Test
     public void modifyDataPolicyWithBadParam() throws Exception {
 
-        final String expected = "Unrecognized Data Policy parameter: cat";
+        final String expected = "Unrecognized Data Policy parameter: cat\n";
 
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "modify_data_policy", "-i", "fake",
                 "--modify-params",  "name:fred,blobbing_enabled:false,default_blob_size:1073741824,default_get_job_priority:HIGH,end_to_end_crc_required:false,rebuild_priority:LOW,versioning:NONE,cat:dog"});


### PR DESCRIPTION
added --log-verbose, --log-trace, and --log-debug which  mirror --verbose, -trace, and --debug but write to ./ds3_logs/spectra.log. Using the ch.qos.logback.core.rolling.TimeBasedRollingPolicy previous days' logs will be archived to spectraYYYY-MM-DD.log.