### PR TITLE
JAVACLI-79 Instantiate logback config only as needed.

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
@@ -16,8 +16,17 @@
 package com.spectralogic.ds3cli;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.core.encoder.Encoder;
 import ch.qos.logback.classic.filter.ThresholdFilter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.rolling.DefaultTimeBasedFileNamingAndTriggeringPolicy;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
 import com.spectralogic.ds3cli.util.Ds3Provider;
 import com.spectralogic.ds3cli.util.FileUtils;
 import com.spectralogic.ds3cli.util.Utils;
@@ -25,31 +34,91 @@ import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.Ds3ClientBuilder;
 import com.spectralogic.ds3client.models.common.Credentials;
 import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
-import com.spectralogic.ds3client.networking.FailedRequestException;
 import org.slf4j.LoggerFactory;
+import java.util.Date;
 
 public class Main {
-    private final static ch.qos.logback.classic.Logger LOG = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Main.class);
+    // initialize and add appenders to root logger
+    private final static ch.qos.logback.classic.Logger LOG =  (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    private final static String LOG_FORMAT_PATTERN = "%d{yyyy-MM-dd HH:mm:ss} +++ %msg%n";
+    private final static String LOG_ARCHIVE_FILE_PATTERN =  "spectra%d{yyyy-MM-dd}.log";
+    private final static String LOG_DIR = "./ds3logs/";
+    private final static String LOG_FILE_NAME = "spectra.log";
+
 
     private static void configureLogging(final String consoleLevel, final String fileLevel) {
+
+        final LoggerContext loggerContext = LOG.getLoggerContext();
+        loggerContext.reset();
+
         // turn root log wide open, filters will be set to argument levels
         LOG.setLevel(Level.ALL);
 
-        /*
-        final Appender fileAppender =  LOG.getAppender("LOGFILE");
-        final ch.qos.logback.classic.filter.ThresholdFilter fileFilter = new ThresholdFilter();
-        fileFilter.setLevel(consoleLevel);
-        fileFilter.setName(consoleLevel);
-        fileAppender.addFilter(fileFilter);
-        fileFilter.start();
-        */
+        if (!consoleLevel.equalsIgnoreCase(Level.OFF.toString())) {
+            // create and add console appender
+            final PatternLayoutEncoder consoleEncoder = new PatternLayoutEncoder();
+            consoleEncoder.setContext(loggerContext);
+            consoleEncoder.setPattern(LOG_FORMAT_PATTERN);
+            consoleEncoder.start();
 
-        final Appender consoleAppender =  LOG.getAppender("STDOUT");
-        final ch.qos.logback.classic.filter.ThresholdFilter consoleFilter = new ThresholdFilter();
-        consoleFilter.setLevel(fileLevel);
-        consoleFilter.setName(fileLevel);
-        consoleAppender.addFilter(consoleFilter);
-        consoleFilter.start();
+            final ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<ILoggingEvent>();
+            consoleAppender.setContext(loggerContext);
+            consoleAppender.setName("STDOUT");
+            consoleAppender.setEncoder(consoleEncoder);
+
+            final ch.qos.logback.classic.filter.ThresholdFilter consoleFilter = new ThresholdFilter();
+            consoleFilter.setLevel(consoleLevel);
+            consoleFilter.setName(consoleLevel);
+            consoleFilter.start();
+            consoleAppender.addFilter(consoleFilter);
+
+            consoleAppender.start();
+            LOG.addAppender(consoleAppender);
+        }
+
+        if (!fileLevel.equalsIgnoreCase(Level.OFF.toString())) {
+            // create file appender only if needed.
+            // if done in the xml, it will create an empty file
+
+            final RollingFileAppender<ILoggingEvent> fileAppender = new RollingFileAppender<ILoggingEvent>();
+            final TimeBasedRollingPolicy<ILoggingEvent> timeBasedRollingPolicy = new TimeBasedRollingPolicy<ILoggingEvent>();
+            final DefaultTimeBasedFileNamingAndTriggeringPolicy<ILoggingEvent> timeBasedTriggeringPolicy = new DefaultTimeBasedFileNamingAndTriggeringPolicy<ILoggingEvent>();
+
+            fileAppender.setContext(loggerContext);
+            timeBasedTriggeringPolicy.setContext(loggerContext);
+            timeBasedRollingPolicy.setContext(loggerContext);
+
+            fileAppender.setRollingPolicy(timeBasedRollingPolicy);
+            timeBasedRollingPolicy.setParent(fileAppender);
+            timeBasedRollingPolicy.setTimeBasedFileNamingAndTriggeringPolicy(timeBasedTriggeringPolicy);
+            timeBasedTriggeringPolicy.setTimeBasedRollingPolicy(timeBasedRollingPolicy);
+
+            timeBasedRollingPolicy.setFileNamePattern(LOG_DIR + LOG_ARCHIVE_FILE_PATTERN);
+            timeBasedRollingPolicy.start();
+
+            timeBasedTriggeringPolicy.setCurrentTime(new Date().getTime());
+            timeBasedTriggeringPolicy.start();
+
+            final PatternLayoutEncoder fileEncoder = new PatternLayoutEncoder();
+            fileEncoder.setContext(loggerContext);
+            fileEncoder.setPattern(LOG_FORMAT_PATTERN);
+            fileEncoder.start();
+
+            fileAppender.setTriggeringPolicy(timeBasedTriggeringPolicy);
+            fileAppender.setEncoder((Encoder<ILoggingEvent>)fileEncoder);
+            fileAppender.setFile(LOG_DIR  +  LOG_FILE_NAME);
+            fileAppender.setName("LOGFILE");
+            timeBasedRollingPolicy.start();
+
+            final ch.qos.logback.classic.filter.ThresholdFilter fileFilter = new ThresholdFilter();
+            fileFilter.setLevel(fileLevel);
+            fileFilter.setName(fileLevel);
+            fileFilter.start();
+            fileAppender.addFilter(fileFilter);
+
+            LOG.addAppender((Appender)fileAppender);
+            fileAppender.start();
+        }
     }
 
     public static void main(final String[] args) {
@@ -58,7 +127,7 @@ public class Main {
             final Arguments arguments = new Arguments(args);
 
             // turn root log wide open, filters will be set to argument levels
-            configureLogging(arguments.getFileLogLevel().toString(), arguments.getConsoleLogLevel().toString());
+            configureLogging(arguments.getConsoleLogLevel().toString(), arguments.getFileLogLevel().toString());
 
             LOG.info("Version: " + arguments.getVersion());
             LOG.info("Console log level: " + arguments.getConsoleLogLevel().toString());
@@ -88,13 +157,7 @@ public class Main {
             System.exit(response.getReturnCode());
         } catch (final Exception e) {
             System.out.println("ERROR: " + e.getMessage());
-            if (LOG.isInfoEnabled()) {
-                e.printStackTrace();
-                if (e instanceof FailedRequestException) {
-                    LOG.info("Printing out the response from the server:");
-                    LOG.info(((FailedRequestException) e).getResponseString());
-                }
-            }
+            LOG.info("Stack trace: ", e);
             System.exit(2);
         }
     }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
@@ -93,7 +93,7 @@ public class Main {
             sizeBasedRollingPolicy.setMinIndex(0);
             sizeBasedRollingPolicy.setMaxIndex(99);
 
-            Path logFilePath = FileSystems.getDefault().getPath(LOG_DIR, LOG_FILE_NAME);
+            final Path logFilePath = FileSystems.getDefault().getPath(LOG_DIR, LOG_FILE_NAME);
             fileAppender.setFile(logFilePath.toString());
             sizeBasedRollingPolicy.setFileNamePattern(LOG_DIR + LOG_ARCHIVE_FILE_PATTERN);
             sizeBasedRollingPolicy.start();

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Main.java
@@ -34,6 +34,7 @@ import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.Ds3ClientBuilder;
 import com.spectralogic.ds3client.models.common.Credentials;
 import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
+import com.spectralogic.ds3client.networking.FailedRequestException;
 import org.slf4j.LoggerFactory;
 import java.util.Date;
 
@@ -155,6 +156,12 @@ public class Main {
             final CommandResponse response = runner.call();
             System.out.println(response.getMessage());
             System.exit(response.getReturnCode());
+        } catch (final FailedRequestException e) {
+            System.out.println("ERROR: " + e.getMessage());
+            LOG.info("Stack trace: ", e);
+            LOG.info("Printing out the response from the server:");
+            LOG.info(((FailedRequestException) e).getResponseString());
+            System.exit(2);
         } catch (final Exception e) {
             System.out.println("ERROR: " + e.getMessage());
             LOG.info("Stack trace: ", e);

--- a/ds3_java_cli/src/main/resources/logback-test.xml
+++ b/ds3_java_cli/src/main/resources/logback-test.xml
@@ -1,48 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="false">
 
-    <!--<property name="CLI_HOME" value="./ds3logs" /> -->
-
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ALL</level>
-            <name>all</name>
-        </filter>
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} +++ %msg%n</pattern>
-        </encoder>
-    </appender>
-    <!--
-    <appender name="LOGFILE"
-              class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ALL</level>
-            <name>all</name>
-        </filter>
-        <file>${CLI_HOME}/spectra.log</file>
-
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${CLI_HOME}/spectra.%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <Pattern>
-                %d{yyyy-MM-dd HH:mm:ss} +++ %msg%n
-            </Pattern>
-        </encoder>
-    </appender>
-
-    -->
-    <logger name="com.spectralogic.ds3cli.Main" level="off"
+    <logger name="com.spectralogic.ds3cli.Main" level="all"
             additivity="false">
         <level value="ALL" />
-        <appender-ref ref="STDOUT" />
-        <!--<appender-ref ref="LOGFILE" />-->
     </logger>
 
     <root level="ALL">
-        <appender-ref ref="STDOUT" />
-        <!--<appender-ref ref="LOGFILE" />-->
     </root>
 </configuration>


### PR DESCRIPTION
If you configure the file logger in XML, it will create an empty file. This creates a file appender only if we are writing to it.