### PR TITLE
Fix java cli tests

### DIFF
--- a/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
+++ b/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
@@ -280,8 +280,8 @@ public class FeatureIntegration_Test {
         try {
             // For a Get with sync, the local file needs to be older than the server copy
             Util.copyFile(objectName, Util.RESOURCE_BASE_NAME, Util.DOWNLOAD_BASE_NAME);
-            File file = new File(Util.DOWNLOAD_BASE_NAME + "/" + objectName);
-            DateTime modTime = new DateTime().minusHours(1);
+            final File file = new File(Util.DOWNLOAD_BASE_NAME + File.separator + objectName);
+            final DateTime modTime = new DateTime().minusHours(1);
             file.setLastModified(modTime.getMillis());
 
             Util.createBucket(client, bucketName);
@@ -289,7 +289,7 @@ public class FeatureIntegration_Test {
 
             final Arguments args = new Arguments(new String[]{"--http", "-c", "get_object", "-b", bucketName,
                     "-o", objectName, "-d", Util.DOWNLOAD_BASE_NAME, "--sync"});
-            CommandResponse response = Util.command(client, args);
+            final CommandResponse response = Util.command(client, args);
             assertThat(response.getMessage(), is("SUCCESS: Finished syncing object."));
         } finally {
             Util.deleteBucket(client, bucketName);
@@ -304,8 +304,8 @@ public class FeatureIntegration_Test {
         try {
             // get_object sets the last_modified property to that of the original file, so we need to spoof for comparison
             Util.copyFile(objectName, Util.RESOURCE_BASE_NAME, Util.DOWNLOAD_BASE_NAME);
-            File newFile = new File(Util.DOWNLOAD_BASE_NAME + "/" + objectName);
-            DateTime now = new DateTime();
+            final File newFile = new File(Util.DOWNLOAD_BASE_NAME + File.separator + objectName);
+            final DateTime now = new DateTime();
             newFile.setLastModified(now.getMillis());
 
             Util.createBucket(client, bucketName);
@@ -313,7 +313,7 @@ public class FeatureIntegration_Test {
 
             final Arguments args = new Arguments(new String[]{"--http", "-c", "get_object", "-b", bucketName,
                     "-o", objectName, "-d", Util.DOWNLOAD_BASE_NAME, "--sync"});
-            CommandResponse response = Util.command(client, args);
+            final CommandResponse response = Util.command(client, args);
             assertThat(response.getMessage(), is("SUCCESS: No need to sync " + objectName));
         } finally {
             Util.deleteBucket(client, bucketName);
@@ -330,7 +330,7 @@ public class FeatureIntegration_Test {
 
             final Arguments args = new Arguments(new String[]{"--http", "-c", "get_bulk", "-b", bucketName,
                     "-d", Util.DOWNLOAD_BASE_NAME, "--sync"});
-            CommandResponse response = Util.command(client, args);
+            final CommandResponse response = Util.command(client, args);
             assertThat(response.getMessage(), is("SUCCESS: Synced all the objects from " + bucketName + " to ." + File.separator + "." + File.separator + "output"));
         } finally {
             Util.deleteBucket(client, bucketName);
@@ -352,7 +352,7 @@ public class FeatureIntegration_Test {
 
             // get_bulk sets the last_modified property to that of the original file, so we need to spoof for comparison
             final File destFolder = new File(Util.DOWNLOAD_BASE_NAME);
-            DateTime now = new DateTime();
+            final DateTime now = new DateTime();
             for( final File currentFile : destFolder.listFiles()) {
                 currentFile.setLastModified(now.getMillis());
             }

--- a/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
+++ b/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
@@ -484,7 +484,7 @@ public class FeatureIntegration_Test {
             final ImmutableMultimap<String, String> metadata = headObject.getData().getMetadata();
 
             assertThat(metadata, is(notNullValue()));
-            assertThat(metadata.size(), is(1));
+            assertThat(metadata.size(), is(2)); // x-amz-meta-ds3-last-modified is added automatically
 
             final ImmutableCollection<String> collection = metadata.get("key");
 
@@ -519,7 +519,7 @@ public class FeatureIntegration_Test {
             final ImmutableMultimap<String, String> metadata = headObject.getData().getMetadata();
 
             assertThat(metadata, is(notNullValue()));
-            assertThat(metadata.size(), is(2));
+            assertThat(metadata.size(), is(3)); // x-amz-meta-ds3-last-modified is added automatically
 
             ImmutableCollection<String> collection = metadata.get("key");
             assertThat(collection.size(), is(1));

--- a/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
+++ b/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
@@ -34,6 +34,7 @@ import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
 import com.spectralogic.ds3client.models.ChecksumType;
 import com.spectralogic.ds3client.models.bulk.Ds3Object;
 import com.spectralogic.ds3client.utils.ResourceUtils;
+import org.joda.time.DateTime;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,9 +48,12 @@ import java.io.InputStream;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
 import java.security.SignatureException;
+import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.UUID;
 
+import static java.lang.Thread.sleep;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.junit.Assert.assertThat;
@@ -260,9 +264,8 @@ public class FeatureIntegration_Test {
             assertThat(cliJobResponse.getData().getJobDetails().getObjects(), is(Collections.<String>emptyList()));
             assertThat(cliJobResponse.getData().getJobDetails().getPriority(), is("HIGH"));
             assertThat(cliJobResponse.getData().getJobDetails().getRequestType(), is("GET"));
-            //TODO add those tests when testing using BP 1.2 is not relevant anymore
-            //assertThat(cliJobResponse.getData().getJobDetails().getCachedSizeInBytes(), is(objSize));
-            //assertThat(cliJobResponse.getData().getJobDetails().getCompletedSizeInBytes(), is(objSize));
+            assertThat(cliJobResponse.getData().getJobDetails().getCachedSizeInBytes(), is(objSize));
+            assertThat(cliJobResponse.getData().getJobDetails().getCompletedSizeInBytes(), is(objSize));
             assertThat(cliJobResponse.getData().getJobDetails().getAggregating(), is(false));
 
             assertThat(cliJobResponse.getStatus(), is("OK"));
@@ -276,39 +279,86 @@ public class FeatureIntegration_Test {
     @Test
     public void getObjectWithSync() throws Exception {
         final String bucketName = "test_get_object_with_sync";
+        final String objectName = "beowulf.txt";
         try {
             // For a Get with sync, the local file needs to be older than the server copy
-            Util.copyFile("beowulf.txt", Util.RESOURCE_BASE_NAME, Util.DOWNLOAD_BASE_NAME);
+            Util.copyFile(objectName, Util.RESOURCE_BASE_NAME, Util.DOWNLOAD_BASE_NAME);
+            File file = new File(Util.DOWNLOAD_BASE_NAME + "/" + objectName);
+            DateTime modTime = new DateTime().minusHours(1);
+            file.setLastModified(modTime.getMillis());
 
             Util.createBucket(client, bucketName);
             Util.loadBookTestData(client, bucketName);
 
             final Arguments args = new Arguments(new String[]{"--http", "-c", "get_object", "-b", bucketName,
-                    "-o", "beowulf.txt", "-d", Util.DOWNLOAD_BASE_NAME, "--sync"});
+                    "-o", objectName, "-d", Util.DOWNLOAD_BASE_NAME, "--sync"});
             CommandResponse response = Util.command(client, args);
             assertThat(response.getMessage(), is("SUCCESS: Finished syncing object."));
-
-            response = Util.command(client, args);
-            assertThat(response.getMessage(), is("SUCCESS: No need to sync beowulf.txt"));
-
         } finally {
             Util.deleteBucket(client, bucketName);
-            Util.deleteLocalFile("beowulf.txt");
+            Util.deleteLocalFile(objectName);
+        }
+    }
+
+    @Test
+    public void getObjectWithSyncNoUpdate() throws Exception {
+        final String bucketName = "test_get_object_with_sync_no_update";
+        final String objectName = "beowulf.txt";
+        try {
+            // get_object sets the last_modified property to that of the original file, so we need to spoof for comparison
+            Util.copyFile(objectName, Util.RESOURCE_BASE_NAME, Util.DOWNLOAD_BASE_NAME);
+            File newFile = new File(Util.DOWNLOAD_BASE_NAME + "/" + objectName);
+            DateTime now = new DateTime();
+            newFile.setLastModified(now.getMillis());
+
+            Util.createBucket(client, bucketName);
+            Util.loadBookTestData(client, bucketName);
+
+            final Arguments args = new Arguments(new String[]{"--http", "-c", "get_object", "-b", bucketName,
+                    "-o", objectName, "-d", Util.DOWNLOAD_BASE_NAME, "--sync"});
+            CommandResponse response = Util.command(client, args);
+            assertThat(response.getMessage(), is("SUCCESS: No need to sync " + objectName));
+        } finally {
+            Util.deleteBucket(client, bucketName);
+            Util.deleteLocalFile(objectName);
         }
     }
 
     @Test
     public void getBulkObjectWithSync() throws Exception {
-        final String bucketName = "test_get_bulk_object_with_sync";
+        final String bucketName = "test_get_bulk_object_with_sync_no_update";
         try {
-
             Util.createBucket(client, bucketName);
             Util.loadBookTestData(client, bucketName);
 
             final Arguments args = new Arguments(new String[]{"--http", "-c", "get_bulk", "-b", bucketName,
                     "-d", Util.DOWNLOAD_BASE_NAME, "--sync"});
             CommandResponse response = Util.command(client, args);
-            assertThat(response.getMessage(), is("SUCCESS: Synced all the objects from test_get_object to ." + File.separator + "." + File.separator + "output"));
+            assertThat(response.getMessage(), is("SUCCESS: Synced all the objects from " + bucketName + " to ." + File.separator + "." + File.separator + "output"));
+        } finally {
+            Util.deleteBucket(client, bucketName);
+            Util.deleteLocalFiles();
+        }
+    }
+
+    @Test
+    public void getBulkObjectWithSyncNoUpdate() throws Exception {
+        final String bucketName = "test_get_bulk_object_with_sync_no_update";
+        try {
+            Util.createBucket(client, bucketName);
+            Util.loadBookTestData(client, bucketName);
+
+            final Arguments args = new Arguments(new String[]{"--http", "-c", "get_bulk", "-b", bucketName,
+                    "-d", Util.DOWNLOAD_BASE_NAME, "--sync"});
+            CommandResponse response = Util.command(client, args);
+            assertThat(response.getMessage(), is("SUCCESS: Synced all the objects from " + bucketName + " to ." + File.separator + "." + File.separator + "output"));
+
+            // get_bulk sets the last_modified property to that of the original file, so we need to spoof for comparison
+            final File destFolder = new File(Util.DOWNLOAD_BASE_NAME);
+            DateTime now = new DateTime();
+            for( final File currentFile : destFolder.listFiles()) {
+                currentFile.setLastModified(now.getMillis());
+            }
 
             response = Util.command(client, args);
             assertThat(response.getMessage(), is("SUCCESS: All files are up to date"));
@@ -496,8 +546,10 @@ public class FeatureIntegration_Test {
 
             final Arguments args = new Arguments(new String[]{"--http", "-c", "get_physical_placement", "-b", bucketName, "-o", "beowulf.txt" });
             final CommandResponse response = Util.command(client, args);
-            assertTrue(response.getMessage().contains("| Object Name | ID | In Cache | Length | Offset | Latest | Version |"));
-            assertTrue(response.getMessage().contains("| beowulf.txt |    | Unknown  | 294059 | 0      | true   | 1       |"));
+            System.out.println(response.getMessage());
+            assertTrue(response.getMessage().contains("| Object Name |                  ID                  | In Cache | Length | Offset | Latest | Version |"));
+            assertTrue(response.getMessage().contains("| beowulf.txt |"));
+            assertTrue(response.getMessage().contains("| true     | 294059 | 0      | true   | 1       |"));
 
         } finally {
             Util.deleteBucket(client, bucketName);

--- a/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
+++ b/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
@@ -543,7 +543,6 @@ public class FeatureIntegration_Test {
 
             final Arguments args = new Arguments(new String[]{"--http", "-c", "get_physical_placement", "-b", bucketName, "-o", "beowulf.txt" });
             final CommandResponse response = Util.command(client, args);
-            System.out.println(response.getMessage());
             assertTrue(response.getMessage().contains("| Object Name |                  ID                  | In Cache | Length | Offset | Latest | Version |"));
             assertTrue(response.getMessage().contains("| beowulf.txt |"));
             assertTrue(response.getMessage().contains("| true     | 294059 | 0      | true   | 1       |"));

--- a/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
+++ b/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
@@ -48,12 +48,9 @@ import java.io.InputStream;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
 import java.security.SignatureException;
-import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.UUID;
 
-import static java.lang.Thread.sleep;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.junit.Assert.assertThat;

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutObject.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutObject.java
@@ -135,7 +135,10 @@ public class PutObject extends CliCommand<DefaultResult> {
             putJob.withMetadata(new Ds3ClientHelpers.MetadataAccess() {
                 @Override
                 public Map<String, String> getMetadataValue(final String s) {
-                    return metadata;
+
+                    return new ImmutableMap.Builder<String, String>()
+                            .putAll(Utils.getMetadataValues(objectPath))
+                            .putAll(metadata).build();
                 }
             });
         }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutObject.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutObject.java
@@ -128,7 +128,8 @@ public class PutObject extends CliCommand<DefaultResult> {
     }
 
     private void transfer(final Ds3ClientHelpers helpers, final Ds3Object ds3Obj) throws SignatureException, IOException, XmlProcessingException {
-        final Ds3ClientHelpers.Job putJob = helpers.startWriteJob(this.bucketName, Lists.newArrayList(ds3Obj));
+        final Ds3ClientHelpers.Job putJob = helpers.startWriteJob(this.bucketName, Lists.newArrayList(ds3Obj))
+                .withMaxParallelRequests(this.numberOfThreads);
 
         if (!Guard.isMapNullOrEmpty(metadata)) {
             putJob.withMetadata(new Ds3ClientHelpers.MetadataAccess() {
@@ -139,13 +140,7 @@ public class PutObject extends CliCommand<DefaultResult> {
             });
         }
 
-        putJob.withMaxParallelRequests(this.numberOfThreads);
-        putJob.withMetadata(new Ds3ClientHelpers.MetadataAccess() {
-            @Override
-            public Map<String, String> getMetadataValue(final String filename) {
-                return Utils.getMetadataValues(objectPath);
-            }
-        }).transfer(new Ds3ClientHelpers.ObjectChannelBuilder() {
+        putJob.transfer(new Ds3ClientHelpers.ObjectChannelBuilder() {
             @Override
             public SeekableByteChannel buildChannel(final String s) throws IOException {
                 return FileChannel.open(objectPath, StandardOpenOption.READ);

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -17,6 +17,7 @@ package com.spectralogic.ds3cli;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.spectralogic.ds3cli.command.PutObject;
 import com.spectralogic.ds3cli.exceptions.BadArgumentException;
 import com.spectralogic.ds3cli.exceptions.SyncNotSupportedException;
 import com.spectralogic.ds3cli.util.*;
@@ -37,6 +38,8 @@ import org.apache.commons.io.IOUtils;
 import org.hamcrest.core.StringEndsWith;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -576,6 +579,7 @@ public class Ds3Cli_Test {
         when(mockedFileUtils.size(any(Path.class))).thenReturn(100L);
         when(helpers.startWriteJob(eq("bucketName"), (Iterable<Ds3Object>) isNotNull())).thenReturn(mockedPutJob);
         when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMaxParallelRequests(any(int.class))).thenReturn(mockedPutJob);
 
         PowerMockito.mockStatic(BlackPearlUtils.class);
 
@@ -597,6 +601,7 @@ public class Ds3Cli_Test {
         when(helpers.listObjects(eq("bucketName"))).thenReturn(retObj);
         when(helpers.startWriteJob(eq("bucketName"), (Iterable<Ds3Object>) isNotNull())).thenReturn(mockedPutJob);
         when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMaxParallelRequests(any(int.class))).thenReturn(mockedPutJob);
 
         final FileUtils mockedFileUtils = mock(FileUtils.class);
         when(mockedFileUtils.exists(any(Path.class))).thenReturn(true);
@@ -662,6 +667,7 @@ public class Ds3Cli_Test {
         when(mockedFileUtils.size(any(Path.class))).thenReturn(100L);
         when(helpers.startWriteJob(eq("bucketName"), (Iterable<Ds3Object>) isNotNull())).thenReturn(mockedPutJob);
         when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMaxParallelRequests(any(int.class))).thenReturn(mockedPutJob);
 
         PowerMockito.mockStatic(BlackPearlUtils.class);
 


### PR DESCRIPTION
Metadata was not being set correctly (the input hash was being overwritten)

Sync tests needed to be updated for gets because the local last modified is now set by get_object / get_bulk to match the original file