### PR TITLE
Javacli98 add --ignore-naming-conflicts flag for Bulk Put  

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
         compile 'ch.qos.logback:logback-core:1.1.6'
         compile 'ch.qos.logback:logback-classic:1.1.6'
         compile 'com.google.guava:guava:19.0'
-        compile 'com.spectralogic.ds3:ds3-sdk:3.2.2'
+        compile 'com.spectralogic.ds3:ds3-sdk:3.2.2'  
         testCompile ('org.mockito:mockito-core:1.10.19') {
             exclude group: 'org.hamcrest'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
         compile 'ch.qos.logback:logback-core:1.1.6'
         compile 'ch.qos.logback:logback-classic:1.1.6'
         compile 'com.google.guava:guava:19.0'
-        compile 'com.spectralogic.ds3:ds3-sdk:3.0.6'
+        compile 'com.spectralogic.ds3:ds3-sdk:3.2.2-SNAPSHOT'
         testCompile ('org.mockito:mockito-core:1.10.19') {
             exclude group: 'org.hamcrest'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
         compile 'ch.qos.logback:logback-core:1.1.6'
         compile 'ch.qos.logback:logback-classic:1.1.6'
         compile 'com.google.guava:guava:19.0'
-        compile 'com.spectralogic.ds3:ds3-sdk:3.2.2-SNAPSHOT'
+        compile 'com.spectralogic.ds3:ds3-sdk:3.2.2'
         testCompile ('org.mockito:mockito-core:1.10.19') {
             exclude group: 'org.hamcrest'
         }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
@@ -73,6 +73,8 @@ public class Arguments {
     private Level consoleLogLevel;
     private Level fileLogLevel;
 
+    private boolean ignoreNamingCponflicts = false;
+
     // don't use Logger because the user's preferences are not yet set
     // collect log info that will be logged by Main
     private static StringBuilder argumentLog = new StringBuilder("Argument processing");
@@ -168,6 +170,8 @@ public class Arguments {
         noFollowSymlinks.setLongOpt("no-follow-symlinks");
         final Option followSymLinks = new Option(null, false, "Set to follow symlinks");
         followSymLinks.setLongOpt("follow-symlinks");
+        final Option ignoreNamingConflicts = new Option(null, false, "Set true to ignore existing files of the same name during a bulk put");
+        followSymLinks.setLongOpt("ignore-naming-conflicts");
 
         final Option metadata = Option.builder()
                 .longOpt("metadata")
@@ -225,6 +229,7 @@ public class Arguments {
         this.options.addOption(metadata);
         this.options.addOption(modifyParams);
         this.options.addOption(discard);
+        this.options.addOption(ignoreNamingConflicts);
         this.processCommandLine();
     }
 
@@ -429,6 +434,10 @@ public class Arguments {
 
         if (cmd.hasOption("discard")) {
             this.setDiscard(true);
+        }
+
+        if (cmd.hasOption("ignore-naming-conflicts")) {
+            this.setIgnoreNamingCponflicts(true);
         }
     }
 
@@ -737,5 +746,10 @@ public class Arguments {
     public Level getFileLogLevel() { return this.fileLogLevel; }
 
     void setFileLogLevel(Level file) {this.fileLogLevel = file; }
+
+    public boolean doIgnoreNamingConflicts() { return this.ignoreNamingCponflicts; }
+
+    void setIgnoreNamingCponflicts(final boolean ignore) { this.ignoreNamingCponflicts = ignore; }
+
 }
 

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
@@ -170,7 +170,7 @@ public class Arguments {
         noFollowSymlinks.setLongOpt("no-follow-symlinks");
         final Option followSymLinks = new Option(null, false, "Set to follow symlinks");
         followSymLinks.setLongOpt("follow-symlinks");
-        final Option ignoreNamingConflicts = new Option(null, false, "Set true to ignore existing files of the same name during a bulk put");
+        final Option ignoreNamingConflicts = new Option(null, false, "Set true to ignore existing files of the same name and size during a bulk put");
         ignoreNamingConflicts.setLongOpt("ignore-naming-conflicts");
 
         final Option metadata = Option.builder()

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/Arguments.java
@@ -73,7 +73,7 @@ public class Arguments {
     private Level consoleLogLevel;
     private Level fileLogLevel;
 
-    private boolean ignoreNamingCponflicts = false;
+    private boolean ignoreNamingConflicts = false;
 
     // don't use Logger because the user's preferences are not yet set
     // collect log info that will be logged by Main
@@ -171,7 +171,7 @@ public class Arguments {
         final Option followSymLinks = new Option(null, false, "Set to follow symlinks");
         followSymLinks.setLongOpt("follow-symlinks");
         final Option ignoreNamingConflicts = new Option(null, false, "Set true to ignore existing files of the same name during a bulk put");
-        followSymLinks.setLongOpt("ignore-naming-conflicts");
+        ignoreNamingConflicts.setLongOpt("ignore-naming-conflicts");
 
         final Option metadata = Option.builder()
                 .longOpt("metadata")
@@ -437,7 +437,7 @@ public class Arguments {
         }
 
         if (cmd.hasOption("ignore-naming-conflicts")) {
-            this.setIgnoreNamingCponflicts(true);
+            this.setIgnoreNamingConflicts(true);
         }
     }
 
@@ -747,9 +747,9 @@ public class Arguments {
 
     void setFileLogLevel(Level file) {this.fileLogLevel = file; }
 
-    public boolean doIgnoreNamingConflicts() { return this.ignoreNamingCponflicts; }
+    public boolean doIgnoreNamingConflicts() { return this.ignoreNamingConflicts; }
 
-    void setIgnoreNamingCponflicts(final boolean ignore) { this.ignoreNamingCponflicts = ignore; }
+    void setIgnoreNamingConflicts(final boolean ignore) { this.ignoreNamingConflicts = ignore; }
 
 }
 

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/DeleteJob.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/DeleteJob.java
@@ -17,8 +17,6 @@ package com.spectralogic.ds3cli.command;
 
 import com.spectralogic.ds3cli.Arguments;
 import com.spectralogic.ds3cli.models.DefaultResult;
-import com.spectralogic.ds3cli.util.Ds3Provider;
-import com.spectralogic.ds3cli.util.FileUtils;
 import com.spectralogic.ds3client.commands.spectrads3.CancelJobSpectraS3Request;
 import org.apache.commons.cli.MissingOptionException;
 import org.slf4j.Logger;
@@ -31,7 +29,6 @@ public class DeleteJob extends CliCommand<DefaultResult> {
     private final static Logger LOG = LoggerFactory.getLogger(DeleteJob.class);
 
     private UUID id;
-    private boolean force;
 
     public DeleteJob() {
     }
@@ -42,16 +39,13 @@ public class DeleteJob extends CliCommand<DefaultResult> {
             throw new MissingOptionException("The delete job command requires '-i' to be set.");
         }
         this.id = UUID.fromString(args.getId());
-        this.force = args.isForce();
-        if (this.force) {
-            LOG.info("Force flag is true");
-        }
         return this;
     }
 
     @Override
     public DefaultResult call() throws Exception {
-        final CancelJobSpectraS3Request request = new CancelJobSpectraS3Request(id).withForce(this.force);
+        // Force is always on in CancelJobSpectraS3Request
+        final CancelJobSpectraS3Request request = new CancelJobSpectraS3Request(id);
         getClient().cancelJobSpectraS3(request);
         return new DefaultResult("SUCCESS: Deleted job '"+ this.id.toString() +"'");
     }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/DeleteJob.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/DeleteJob.java
@@ -18,6 +18,7 @@ package com.spectralogic.ds3cli.command;
 import com.spectralogic.ds3cli.Arguments;
 import com.spectralogic.ds3cli.models.DefaultResult;
 import com.spectralogic.ds3client.commands.spectrads3.CancelJobSpectraS3Request;
+import com.spectralogic.ds3client.commands.spectrads3.CancelJobSpectraS3Response;
 import org.apache.commons.cli.MissingOptionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +47,7 @@ public class DeleteJob extends CliCommand<DefaultResult> {
     public DefaultResult call() throws Exception {
         // Force is always on in CancelJobSpectraS3Request
         final CancelJobSpectraS3Request request = new CancelJobSpectraS3Request(id);
-        getClient().cancelJobSpectraS3(request);
-        return new DefaultResult("SUCCESS: Deleted job '"+ this.id.toString() +"'");
+        final CancelJobSpectraS3Response response = getClient().cancelJobSpectraS3(request);
+        return new DefaultResult("SUCCESS: Deleted job '" + this.id.toString() + "'");
     }
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
@@ -64,7 +64,7 @@ public class PutBulk extends CliCommand<PutBulkResult> {
     private ImmutableList<Path> pipedFiles;
     private ImmutableMap<String, String> mapNormalizedObjectNameToObjectName = null;
     private boolean followSymlinks;
-    private boolean ignoreNameConflicts;
+    private boolean ignoreNamingConflicts;
 
     public PutBulk() {
     }
@@ -125,8 +125,8 @@ public class PutBulk extends CliCommand<PutBulkResult> {
         this.followSymlinks = args.isFollowSymlinks();
         LOG.info("Follow symlinks has been set to: {}", this.followSymlinks);
 
-        this.ignoreNameConflicts = args.doIgnoreNamingConflicts();
-        LOG.info("Ignore naming conflicts has been set to: {}", this.ignoreNameConflicts);
+        this.ignoreNamingConflicts = args.doIgnoreNamingConflicts();
+        LOG.info("Ignore naming conflicts has been set to: {}", this.ignoreNamingConflicts);
 
         return this;
     }
@@ -164,7 +164,7 @@ public class PutBulk extends CliCommand<PutBulkResult> {
                 WriteJobOptions.create()
                         .withPriority(this.priority)
                         .withWriteOptimization(this.writeOptimization)
-                        .withIgnoreNamingConflicts(this.ignoreNameConflicts));
+                        .withIgnoreNamingConflicts(this.ignoreNamingConflicts));
                 job.withMaxParallelRequests(this.numberOfThreads);
 
         if (this.checksum) {

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
@@ -64,6 +64,7 @@ public class PutBulk extends CliCommand<PutBulkResult> {
     private ImmutableList<Path> pipedFiles;
     private ImmutableMap<String, String> mapNormalizedObjectNameToObjectName = null;
     private boolean followSymlinks;
+    private boolean ignoreNameConflicts;
 
     public PutBulk() {
     }
@@ -122,8 +123,10 @@ public class PutBulk extends CliCommand<PutBulkResult> {
         }
 
         this.followSymlinks = args.isFollowSymlinks();
-
         LOG.info("Follow symlinks has been set to: {}", this.followSymlinks);
+
+        this.ignoreNameConflicts = args.doIgnoreNamingConflicts();
+        LOG.info("Ignore naming conflicts has been set to: {}", this.ignoreNameConflicts);
 
         return this;
     }
@@ -160,8 +163,10 @@ public class PutBulk extends CliCommand<PutBulkResult> {
         final Ds3ClientHelpers.Job job = helpers.startWriteJob(this.bucketName, ds3Objects,
                 WriteJobOptions.create()
                         .withPriority(this.priority)
-                        .withWriteOptimization(this.writeOptimization));
-        job.withMaxParallelRequests(this.numberOfThreads);
+                        .withWriteOptimization(this.writeOptimization)
+                        .withIgnoreNamingConflicts(this.ignoreNameConflicts));
+                job.withMaxParallelRequests(this.numberOfThreads);
+
         if (this.checksum) {
             throw new RuntimeException("Checksum calculation is not currently supported."); //TODO
 //            Logging.log("Performing bulk put with checksum computation enabled");

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -798,6 +798,7 @@ public class Ds3Cli_Test {
                 + "      \"cachedSizeInBytes\" : 0,\n"
                 + "      \"chunkClientProcessingOrderGuarantee\" : \"NONE\",\n"
                 + "      \"completedSizeInBytes\" : 0,\n"
+                + "      \"entirelyInCache\" : false,\n"
                 + "      \"jobId\" : \"aa5df0cc-b03a-4cb9-b69d-56e7367e917f\",\n"
                 + "      \"naked\" : false,\n"
                 + "      \"name\" : null,\n"
@@ -937,6 +938,40 @@ public class Ds3Cli_Test {
     @Test
     public void putBulk() throws Exception {
         final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName", "-d", "dir"});
+        final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
+        final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
+        final FileUtils mockedFileUtils = mock(FileUtils.class);
+
+        final Path p1 = Paths.get("obj1.txt");
+        final Path p2 = Paths.get("obj2.txt");
+        final ImmutableList<Path> retPath = ImmutableList.copyOf(Lists.newArrayList(p1, p2));
+
+        final UUID jobId = UUID.randomUUID();
+        when(mockedPutJob.getJobId()).thenReturn(jobId);
+        final Iterable<Ds3Object> retObj = Lists.newArrayList(new Ds3Object("obj1.txt", 1245), new Ds3Object("obj2.txt", 12345));
+        when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
+        when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
+
+        PowerMockito.mockStatic(Utils.class);
+        when(Utils.getObjectsToPut((Iterable<Path>)isNotNull(), any(Path.class), any(Boolean.class))).thenCallRealMethod();
+        when(Utils.listObjectsForDirectory(any(Path.class))).thenReturn(retPath);
+        when(Utils.getFileName(any(Path.class), eq(p1))).thenReturn("obj1.txt");
+        when(Utils.getFileSize(eq(p1))).thenReturn(1245L);
+        when(Utils.getFileName(any(Path.class), eq(p2))).thenReturn("obj2.txt");
+        when(Utils.getFileSize(eq(p2))).thenReturn(12345L);
+
+        PowerMockito.mockStatic(BlackPearlUtils.class);
+
+        final Ds3Cli cli = new Ds3Cli(new Ds3ProviderImpl(null, helpers), args, mockedFileUtils);
+        final CommandResponse result = cli.call();
+        assertThat(result.getMessage(), is("SUCCESS: Wrote all the files in dir to bucket bucketName"));
+        assertThat(result.getReturnCode(), is(0));
+    }
+
+    @Test
+    public void putBulkWithIgnoreConflicts() throws Exception {
+        final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!",
+                "-a", "access", "-c", "put_bulk", "-b", "bucketName", "-d", "dir", "--ignore-naming-conflicts"});
         final Ds3ClientHelpers helpers = mock(Ds3ClientHelpers.class);
         final Ds3ClientHelpers.Job mockedPutJob = mock(Ds3ClientHelpers.Job.class);
         final FileUtils mockedFileUtils = mock(FileUtils.class);

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -978,11 +978,11 @@ public class Ds3Cli_Test {
 
         final Path p1 = Paths.get("obj1.txt");
         final Path p2 = Paths.get("obj2.txt");
-        final ImmutableList<Path> retPath = ImmutableList.copyOf(Lists.newArrayList(p1, p2));
+        final ImmutableList<Path> retPath = ImmutableList.of(p1, p2);
 
         final UUID jobId = UUID.randomUUID();
         when(mockedPutJob.getJobId()).thenReturn(jobId);
-        final Iterable<Ds3Object> retObj = Lists.newArrayList(new Ds3Object("obj1.txt", 1245), new Ds3Object("obj2.txt", 12345));
+        final Iterable<Ds3Object> retObj = ImmutableList.of(new Ds3Object("obj1.txt", 1245), new Ds3Object("obj2.txt", 12345));
         when(helpers.startWriteJob(eq("bucketName"), eq(retObj), any(WriteJobOptions.class))).thenReturn(mockedPutJob);
         when(mockedPutJob.withMetadata((Ds3ClientHelpers.MetadataAccess) isNotNull())).thenReturn(mockedPutJob);
 


### PR DESCRIPTION
Also remove --force flag from Delete Job. It is now always set to force in the sdk (artifact of 3.2 merge?)