### PR TITLE
Fixed help text

### DIFF
--- a/ds3_java_cli/src/main/resources/com/spectralogic/dscli/help.properties
+++ b/ds3_java_cli/src/main/resources/com/spectralogic/dscli/help.properties
@@ -47,7 +47,7 @@ DELETE_BUCKET = Deletes an empty bucket.\n\
 
 DELETE_OBJECT = Permanently deletes an object.\n\
         Requires the '-b' parameter to specify bucketname.\n\
-        Requires the '-i' parameter to specify object name (UUID or name).\n\n\
+        Requires the '-o' parameter to specify object name (UUID or name).\n\n\
         Use the get_service command to retrieve a list of buckets.\n\
         Use the get_bucket command to retrieve a list of objects.
 


### PR DESCRIPTION
I discovered the cli command delete_object requires -o while the help listed -i.