### PR TITLE
JAVACLI-129: Print more message information on unknown errors

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/exceptions/DefaultExceptionHandler.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/exceptions/DefaultExceptionHandler.java
@@ -30,11 +30,14 @@ public class DefaultExceptionHandler<T extends Throwable>  implements Ds3Excepti
     }
 
     public String format(final T e) {
-        String message
-                = "Error (" + e.getClass().getSimpleName() + "): " + e.getMessage();
+        final StringBuilder message = new StringBuilder("Error (");
+        message.append(e.getClass().getSimpleName());
+        message.append("): ");
+        message.append(e.getMessage());
         if (e.getCause() != null && !Guard.isStringNullOrEmpty(e.getCause().getMessage())) {
-            message += "\nCause: " + e.getCause().getMessage();
+            message.append("\nCause: ");
+            message.append(e.getCause().getMessage());
         }
-        return message;
+        return message.toString();
     }
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/exceptions/DefaultExceptionHandler.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/exceptions/DefaultExceptionHandler.java
@@ -15,6 +15,7 @@
 
 package com.spectralogic.ds3cli.exceptions;
 
+import com.spectralogic.ds3client.utils.Guard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,10 +30,11 @@ public class DefaultExceptionHandler<T extends Throwable>  implements Ds3Excepti
     }
 
     public String format(final T e) {
-        final String message = "Error (" + e.getClass().getSimpleName() +
-                "): " +
-                e.getMessage();
+        String message
+                = "Error (" + e.getClass().getSimpleName() + "): " + e.getMessage();
+        if (e.getCause() != null && !Guard.isStringNullOrEmpty(e.getCause().getMessage())) {
+            message += "\nCause: " + e.getCause().getMessage();
+        }
         return message;
     }
-
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/exceptions/FailedRequestExceptionHandler.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/exceptions/FailedRequestExceptionHandler.java
@@ -16,6 +16,7 @@
 package com.spectralogic.ds3cli.exceptions;
 
 import com.spectralogic.ds3client.networking.FailedRequestException;
+import com.spectralogic.ds3client.utils.Guard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,14 @@ public class FailedRequestExceptionHandler  implements Ds3ExceptionHandler<Faile
             description.append("target entity already exists.");
         } else {
             description.append("unknown error of (").append(statusCode).append(") while accessing the remote DS3 appliance.");
+            if (!Guard.isStringNullOrEmpty(e.getMessage())) {
+                description.append("\nMessage: ");
+                description.append(e.getMessage());
+            }
+            if (e.getCause() != null && !Guard.isStringNullOrEmpty(e.getCause().getMessage())) {
+                description.append("\nCause: ");
+                description.append(e.getCause().getMessage());
+            }
         }
         return description.toString();
     }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
@@ -324,7 +324,7 @@ public final class Utils {
     }
 
     public static String getBuildDate(final Properties properties) {
-        return properties.get("").toString();
+        return properties.get("build.date").toString();
     }
 
 }


### PR DESCRIPTION
If it's a known error (authorization, 404, &c.) a short message is appropriate. But this removed information that was useful from other errors (like 400s). Print exception message and the cause message if it exists.