### PR TITLE
(JAVACLI-130) Add Absolute dates to filter get_detailed_objects

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetDetailedObjects.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetDetailedObjects.java
@@ -36,6 +36,7 @@ import org.apache.commons.cli.Option;
 import org.slf4j.LoggerFactory;
 
 
+import java.text.ParseException;
 import java.util.Date;
 import javax.annotation.Nullable;
 
@@ -53,6 +54,8 @@ public class GetDetailedObjects extends CliCommand<GetDetailedObjectsResult> {
     private final static String OWNER = "owner";
     private final static String NEWERTHAN = "newerthan";
     private final static String OLDERTHAN = "olderthan";
+    private final static String BEFORE = "before";
+    private final static String AFTER = "after";
     private final static String LARGERTHAN = "largerthan";
     private final static String SMALLERTHAN = "smallerthan";
     private final static long MILLIS_PER_SECOND = 1000L;
@@ -79,7 +82,7 @@ public class GetDetailedObjects extends CliCommand<GetDetailedObjectsResult> {
             return;
         }
         final ImmutableList<String> legalParams
-                = ImmutableList.of(CONTAINS, OWNER, NEWERTHAN,  OLDERTHAN,  LARGERTHAN,  SMALLERTHAN);
+                = ImmutableList.of(CONTAINS, OWNER, NEWERTHAN,  OLDERTHAN,  LARGERTHAN,  SMALLERTHAN, BEFORE, AFTER);
         for (final String paramName : this.filterParams.keySet()) {
             if (!legalParams.contains(paramName)) {
                 throw new BadArgumentException("Unknown filter parameter: " + paramName);
@@ -120,25 +123,47 @@ public class GetDetailedObjects extends CliCommand<GetDetailedObjectsResult> {
         };
     }
 
-    private Predicate<DetailedS3Object> getDatePredicate() throws CommandException {
+    private Predicate<DetailedS3Object> getDatePredicate() throws ParseException {
         if (Guard.isMapNullOrEmpty(this.filterParams)) {
             return Predicates.notNull();
         }
 
+        // newerthan and olderthan are relative
         final String newer = this.filterParams.get(NEWERTHAN);
         final String older = this.filterParams.get(OLDERTHAN);
-        if (Guard.isStringNullOrEmpty(newer) && Guard.isStringNullOrEmpty(older)) {
+        // before and after are actual dates
+        final String after = this.filterParams.get(AFTER);
+        final String before = this.filterParams.get(BEFORE);
+
+        // if any of these are set, create a range for the predicate
+        if (!Guard.isStringNullOrEmpty(newer) && !Guard.isStringNullOrEmpty(older)
+                && !Guard.isStringNullOrEmpty(after) && !Guard.isStringNullOrEmpty(before)) {
             return Predicates.notNull();
         }
-        // if one is specified, default the other
-        final long newerThan = Guard.isStringNullOrEmpty(newer) ? 0L : new Date().getTime() - Utils.dateDiffToSeconds(newer) * MILLIS_PER_SECOND;
-        final long olderThan = Guard.isStringNullOrEmpty(older) ? Long.MAX_VALUE : new Date().getTime() - Utils.dateDiffToSeconds(older) * MILLIS_PER_SECOND;
+
+        long newerThan = 0L;
+        long olderThan = Long.MAX_VALUE;
+
+        if (!Guard.isStringNullOrEmpty(newer)) {
+            newerThan = new Date().getTime() - Utils.dateDiffToSeconds(newer) * MILLIS_PER_SECOND;
+        }
+        if (!Guard.isStringNullOrEmpty(older)) {
+            olderThan = new Date().getTime() - Utils.dateDiffToSeconds(older) * MILLIS_PER_SECOND;
+        }
+        if (!Guard.isStringNullOrEmpty(after)) {
+            newerThan = Utils.parseParamDate(after);
+        }
+        if (!Guard.isStringNullOrEmpty(before)) {
+            olderThan = Utils.parseParamDate(before);
+        }
+        final Date newerThanDate = new Date(newerThan);
+        final Date olderThanDate = new Date(olderThan);
 
         return new Predicate<DetailedS3Object>() {
             @Override
             public boolean apply(@Nullable final DetailedS3Object input) {
-                return input.getCreationDate().after(new Date(newerThan))
-                        && input.getCreationDate().before(new Date(olderThan));
+                return input.getCreationDate().after(newerThanDate)
+                        && input.getCreationDate().before(olderThanDate);
             }
         };
     }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
@@ -307,6 +307,74 @@ public final class Utils {
         return secs;
     }
 
+    /**
+     * parse a string to get absolute date
+     * @param diff format Yyear.Mmonth.Ddate.hhours.mminutes.sseconds e.g., "Y2016.M11.D10.h12"
+     * @return long time in ms
+     */
+    public static long parseParamDate(final String diff) throws java.text.ParseException {
+        // default is 0000-01-01 00:00:00
+        String secs = "00";
+        String mins = "00";
+        String hours = "00";
+        String date = "01";
+        String month = "01";
+        String year = "0000";
+
+        final String[] units = diff.split("[.]");
+        for (final String unit : units) {
+            if (unit.matches("[YMDhms][0-9]+")) {
+                final char unitdesc = unit.charAt(0);
+                switch (unitdesc) {
+                    case 's':
+                        // pad to two chars
+                        secs = unit.replace("s", "00");
+                        secs = secs.substring(secs.length()-2, secs.length());
+                        break;
+                    case 'm':
+                        // pad to two chars
+                        mins = unit.replace("m", "00");
+                        mins = mins.substring(mins.length()-2, mins.length());
+                        break;
+                    case 'h':
+                        // pad to two chars
+                        hours = unit.replace("h", "0");
+                        hours = hours.substring(hours.length()-2, hours.length());
+                        break;
+                    case 'D':
+                        // pad to two chars
+                        date = unit.replace("D", "00");
+                        date = date.substring(date.length()-2, date.length());
+                        break;
+                    case 'M':
+                        // pad to two chars
+                        month = unit.replace("M", "00");
+                        month = month.substring(month.length()-2, month.length());
+                        break;
+                    case 'Y':
+                        // pad to two chars
+                        year = unit.replace("Y", "0000");
+                        year = year.substring(year.length()-4, year.length());
+                        break;
+                }
+            }
+        }
+        // "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        final StringBuilder dateString = new StringBuilder(year);
+        dateString.append("-");
+        dateString.append(month);
+        dateString.append("-");
+        dateString.append(date);
+        dateString.append("T");
+        dateString.append(hours);
+        dateString.append(":");
+        dateString.append(mins);
+        dateString.append(":");
+        dateString.append(secs);
+        dateString.append(".000Z");
+        return Constants.DATE_FORMAT.parse(dateString.toString()).getTime();
+    }
+
     public static Properties readProperties(final String propertyFile) throws IOException {
         final Properties props = new Properties();
         final InputStream input = Arguments.class.getClassLoader().getResourceAsStream(propertyFile);

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/Utils.java
@@ -360,18 +360,18 @@ public final class Utils {
             }
         }
         // "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        final StringBuilder dateString = new StringBuilder(year);
-        dateString.append("-");
-        dateString.append(month);
-        dateString.append("-");
-        dateString.append(date);
-        dateString.append("T");
-        dateString.append(hours);
-        dateString.append(":");
-        dateString.append(mins);
-        dateString.append(":");
-        dateString.append(secs);
-        dateString.append(".000Z");
+        final StringBuilder dateString = new StringBuilder(year)
+            .append("-")
+            .append(month)
+            .append("-")
+            .append(date)
+            .append("T")
+            .append(hours)
+            .append(":")
+            .append(mins)
+            .append(":")
+            .append(secs)
+            .append(".000Z");
         return Constants.DATE_FORMAT.parse(dateString.toString()).getTime();
     }
 

--- a/ds3_java_cli/src/main/resources/com/spectralogic/dscli/help.properties
+++ b/ds3_java_cli/src/main/resources/com/spectralogic/dscli/help.properties
@@ -208,7 +208,10 @@ GET_DETAILED_OBJECTS = Filter an object list by size or creation date. \n\
         Optional '-b' bucket_name \n\
         Optional '--filter-params' to filter results.\n\
         Use key:value pair key:value,key2:value2:... Legal values:\n\
-            newerthan, olderthan specify date from now in format d1.h2.m3.s4 (zero values can be omitted , separate with '.'\n\
+            newerthan, olderthan specify relative date from now in format d1.h2.m3.s4 (zero values can be omitted , separate with '.')\n\
+            before, after specify absolute UTC date in format Y2016.M11.D9.h12 (zero values can be omitted , separate with '.')\n\
+            owner owner name\n\
+            contains string to match in object name \n\
             largerthan, smallerthan object size in bytes \n\n\
         Note: bucket will restrict values returned, filter-params will transfer (potentially large) object list \n\
         and filter client-side.

--- a/ds3_java_cli/src/main/resources/com/spectralogic/dscli/help.properties
+++ b/ds3_java_cli/src/main/resources/com/spectralogic/dscli/help.properties
@@ -221,7 +221,10 @@ GET_DETAILED_OBJECTS_PHYSICAL = Get a list of objects on tape, filtered by size 
         Optional '-b' bucket_name \n\
         Optional '--filter-params' to filter results.\n\
         Use key:value pair key:value,key2:value2:... Legal values:\n\
-            newerthan, olderthan specify date from now in format d1.h2.m3.s4 (zero values can be omitted , separate with '.'\n\
+            newerthan, olderthan specify relative date from now in format d1.h2.m3.s4 (zero values can be omitted , separate with '.')\n\
+            before, after specify absolute UTC date in format Y2016.M11.D9.h12 (zero values can be omitted , separate with '.')\n\
+            owner owner name\n\
+            contains string to match in object name \n\
             largerthan, smallerthan object size in bytes \n\n\
         Note: bucket will restrict values returned, filter-params will transfer (potentially large) object list \n\
         and filter client-side.

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -53,6 +53,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.ParseException;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -3006,5 +3008,19 @@ public class Ds3Cli_Test {
         command.init(args);
     }
 
+    @Test
+    public void parseRelatveDate() throws Exception {
+        final String input = "d1.h2.m3.s4";
+        final long diff = Utils.dateDiffToSeconds(input);
+        assertEquals(diff, (24 * 60 * 60) + (2 * 60 * 60) + (3 * 60) + 4);
+    }
+
+    @Test
+    public void parseAbsoluteDate() throws Exception {
+        final String input = "Y1960.M5.D26";
+        final long parse = Utils.parseParamDate(input);
+        final long construct =  Constants.DATE_FORMAT.parse("1960-05-26T00:00:00.000Z").getTime();
+        assertEquals(parse, construct);
+    }
 
 }


### PR DESCRIPTION
For backwards-compatibility olderthan and newrthan are unchanged, providing relative date before now().

Added before and after for absolute Dates, e.g. before:Y2016.M10.D25,after:Y2016.M9.D30


