### PR TITLE
JAVACLI-149 handle missing -d arg input_bulk

### DIFF
--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/PutBulk.java
@@ -98,10 +98,12 @@ public class PutBulk extends CliCommand<PutBulkResult> {
                 throw new MissingOptionException("Stdin is empty"); //We should never see that since we checked isPipe
             }
             this.mapNormalizedObjectNameToObjectName = this.getNormalizedObjectNameToObjectName(this.pipedFiles);
-        } else {
+        } else if (!Guard.isStringNullOrEmpty(args.getDirectory())) {
             final String srcDir = args.getDirectory();
             this.inputDirectory = Paths.get(srcDir);
             this.prefix = args.getPrefix();
+        } else {
+            throw new BadArgumentException("-d argument required unless using piped input");
         }
 
         this.priority = args.getPriority();

--- a/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
+++ b/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java
@@ -1148,6 +1148,15 @@ public class Ds3Cli_Test {
         command.render();
     }
 
+    @Test(expected = BadArgumentException.class)
+    public void putBulkMissingDirectory() throws Exception {
+        final Arguments args = new Arguments(new String[]{"ds3_java_cli", "-e", "localhost:8080", "-k", "key!", "-a", "access", "-c", "put_bulk", "-b", "bucketName"});
+        final Ds3Client client = mock(Ds3Client.class);
+        final CliCommand command = CliCommandFactory.getCommandExecutor(args.getCommand())
+                .withProvider(new Ds3ProviderImpl(client, null), null);
+        command.init(args);
+    }
+
     @Test
     public void putBulkJson() throws Exception {
         final String expected = "\"Status\" : \"OK\",\n  \"Message\" : \"SUCCESS: Wrote all the files in dir to bucket bucketName\"\n}";


### PR DESCRIPTION
-d is not required because it accepts piped input but previous rev threw null pointer exception