### PR TITLE
Ensure local download folder exists for get_bulk in ds3-cli-integration

### DIFF
--- a/ds3-cli-certification/src/test/java/com/spectralogic/ds3cli/certification/Certification_Test.java
+++ b/ds3-cli-certification/src/test/java/com/spectralogic/ds3cli/certification/Certification_Test.java
@@ -407,7 +407,7 @@ public class Certification_Test {
 
             success = true;
         } catch (final Exception e) {
-            LOG.info("Exception: {}", e.getMessage(), e);
+            LOG.error("Exception: {}", e.getMessage(), e);
         } finally {
             Util.deleteBucket(client, bucketName);
 

--- a/ds3-cli-helpers/src/main/java/com/spectralogic/ds3cli/helpers/Util.java
+++ b/ds3-cli-helpers/src/main/java/com/spectralogic/ds3cli/helpers/Util.java
@@ -39,8 +39,8 @@ import java.util.regex.Pattern;
 
 public final class Util {
     public static final String RESOURCE_BASE_NAME = "./src/test/resources/books/";
-    public static final String DOWNLOAD_BASE_NAME = "./output/";
-    private static final int TRANSER_RETRY_ATTEMPTS = 5;
+    public static final String DOWNLOAD_BASE_NAME = "output/";
+    private static final int TRANSFER_RETRY_ATTEMPTS = 5;
 
     private Util() {
         //pass
@@ -48,7 +48,7 @@ public final class Util {
 
 
     public static CommandResponse command(final Ds3Client client, final Arguments args) throws Exception {
-        final Ds3Provider provider = new Ds3ProviderImpl(client, Ds3ClientHelpers.wrap(client, TRANSER_RETRY_ATTEMPTS));
+        final Ds3Provider provider = new Ds3ProviderImpl(client, Ds3ClientHelpers.wrap(client, TRANSFER_RETRY_ATTEMPTS));
         final FileSystemProvider fileSystemProvider = new FileSystemProviderImpl();
         final CliCommand command = CliCommandFactory.getCommandExecutor(args.getCommand()).withProvider(provider, fileSystemProvider);
         command.init(args);
@@ -151,9 +151,8 @@ public final class Util {
     public static void copyFile(final String fileName, final String from, final String to) throws IOException {
         final Path toDir = Paths.get(to);
 
-        if (Files.notExists(toDir)) {
-            Files.createDirectories(toDir);
-        }
+        // will fail silently if the destination directory already exists
+        Files.createDirectories(toDir);
 
         Files.copy(Paths.get(from + fileName), Paths.get(to + fileName), StandardCopyOption.REPLACE_EXISTING);
     }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBulk.java
@@ -66,7 +66,7 @@ public class GetBulk extends CliCommand<DefaultResult> {
     private boolean discard;
     private int numberOfThreads;
 
-    public static final Option PREFIXES = Option.builder("p").hasArgs().argName("prefixes")
+    private static final Option PREFIXES = Option.builder("p").hasArgs().argName("prefixes")
             .desc("get only objects whose names start with prefix  "
                     + "separate multiple prefixes with spaces").build();
 


### PR DESCRIPTION
Clean up a few integration tests that fail in docker.

root@be7b47b3a3d8:/opt# ./run_tests.sh 
Using Git Repo: https://github.com/DenverM80/ds3_java_cli.git
Using Git Branch: docker_integration_tests
DS3_ENDPOINT sm2u-11.eng.sldomain.com
DS3_SECRET_KEY bbyqucrD
DS3_ACCESS_KEY c3BlY3RyYQ==
cd /opt
git clone https://github.com/DenverM80/ds3_java_cli.git --branch docker_integration_tests --single-branch
Cloning into 'ds3_java_cli'...
remote: Counting objects: 9632, done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 9632 (delta 0), reused 0 (delta 0), pack-reused 9603
Receiving objects: 100% (9632/9632), 2.99 MiB | 4.85 MiB/s, done.
Resolving deltas: 100% (4337/4337), done.
Checking connectivity... done.
cd ds3_java_cli
:ds3_java_cli:compileJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
:ds3_java_cli:processResources
:ds3_java_cli:classes
:ds3_java_cli:genConfigProperties
:ds3_java_cli:jar
:ds3-cli-helpers:compileJava
:ds3-cli-helpers:processResources UP-TO-DATE
:ds3-cli-helpers:classes
:ds3-cli-helpers:compileTestJava
:ds3-cli-helpers:processTestResources UP-TO-DATE
:ds3-cli-helpers:testClasses
:ds3-cli-helpers:test
:ds3-cli-helpers:jar
:ds3-cli-integration:compileJava UP-TO-DATE
:ds3-cli-integration:processResources UP-TO-DATE
:ds3-cli-integration:classes UP-TO-DATE
:ds3-cli-integration:compileTestJava
:ds3-cli-integration:processTestResources
:ds3-cli-integration:testClasses
:ds3-cli-integration:test
:ds3_java_cli:compileTestJava
Note: /opt/ds3_java_cli/ds3_java_cli/src/test/java/com/spectralogic/ds3cli/Ds3Cli_Test.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
:ds3_java_cli:processTestResources UP-TO-DATE
:ds3_java_cli:testClasses
:ds3_java_cli:test

BUILD SUCCESSFUL

Total time: 25.056 secs
root@be7b47b3a3d8:/opt# 
