### PR TITLE
Certification test: fix build error, accept temp dir from environment var

### DIFF
--- a/ds3-cli-certification/src/main/java/com/spectralogic/ds3cli/certification/CertificationUtil.java
+++ b/ds3-cli-certification/src/main/java/com/spectralogic/ds3cli/certification/CertificationUtil.java
@@ -19,6 +19,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.spectralogic.ds3cli.CommandResponse;
 import com.spectralogic.ds3cli.helpers.Util;
+import com.spectralogic.ds3cli.util.SterilizeString;
 import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.commands.spectrads3.*;
 import com.spectralogic.ds3client.models.Priority;
@@ -33,6 +34,7 @@ import javax.annotation.Nullable;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 import static java.lang.Thread.sleep;
@@ -41,13 +43,22 @@ import static java.lang.Thread.sleep;
 public final class CertificationUtil {
 
     private static final Logger LOG =  LoggerFactory.getLogger(CertificationUtil.class);
+    private static final String TEMP_ENVIRONMENT_VARIABLE = "DS3_TEMP_DIR";
+
+    public static Path createTempDs3Directory(final String directoryName) throws IOException {
+        final String tempDir = System.getenv(TEMP_ENVIRONMENT_VARIABLE);
+        if (tempDir == null || tempDir.length() == 0) {
+            return Files.createTempDirectory(directoryName);
+        }
+        return Files.createDirectories(Paths.get(SterilizeString.osSpecificPath(tempDir + "/" + directoryName)));
+    }
 
     public static Path createTempFiles(
-           final String prefix,
-           final int numFiles,
-           final long length) throws IOException {
+            final String prefix,
+            final int numFiles,
+            final long length) throws IOException {
         LOG.info("Creating {} files of size {}...", numFiles, length);
-        final Path tempDir = Files.createTempDirectory(prefix);
+        final Path tempDir = createTempDs3Directory(prefix);
         for(int fileNum = 0; fileNum < numFiles; fileNum++) {
             final File tempFile = new File(tempDir.toString(), prefix + "_" + fileNum);
             try (final RandomAccessFile raf = new RandomAccessFile(tempFile, "rw")) {

--- a/ds3-cli-certification/src/main/java/com/spectralogic/ds3cli/certification/CertificationUtil.java
+++ b/ds3-cli-certification/src/main/java/com/spectralogic/ds3cli/certification/CertificationUtil.java
@@ -27,6 +27,7 @@ import com.spectralogic.ds3client.models.Quiesced;
 import com.spectralogic.ds3client.models.SpectraUser;
 import com.spectralogic.ds3client.models.bulk.Ds3Object;
 import com.spectralogic.ds3client.networking.FailedRequestException;
+import com.spectralogic.ds3client.utils.Guard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,7 @@ public final class CertificationUtil {
 
     public static Path createTempDs3Directory(final String directoryName) throws IOException {
         final String tempDir = System.getenv(TEMP_ENVIRONMENT_VARIABLE);
-        if (tempDir == null || tempDir.length() == 0) {
+        if (Guard.isStringNullOrEmpty(tempDir)) {
             return Files.createTempDirectory(directoryName);
         }
         return Files.createDirectories(Paths.get(SterilizeString.osSpecificPath(tempDir + "/" + directoryName)));

--- a/ds3-cli-certification/src/test/java/com/spectralogic/ds3cli/certification/Certification_Test.java
+++ b/ds3-cli-certification/src/test/java/com/spectralogic/ds3cli/certification/Certification_Test.java
@@ -340,7 +340,7 @@ public class Certification_Test {
             FileUtils.forceDelete(bulkPutLocalTempDir.toFile());
 
             // Start BULK_GET from the same bucket that we just did the BULK_PUT to, with a new local directory
-            final Path bulkGetLocalTempDir = Files.createTempDirectory(bucketName);
+            final Path bulkGetLocalTempDir = CertificationUtil.createTempDs3Directory(bucketName);
 
             final long startGetTime = getCurrentTime();
             OUT.insertLog("Bulk GET from bucket " + bucketName);
@@ -454,7 +454,7 @@ public class Certification_Test {
 
             // check file size
             final List<Path> filesToPut = com.spectralogic.ds3cli.util.FileUtils.listObjectsForDirectory(bulkPutLocalTempDir);
-            final com.spectralogic.ds3cli.util.FileUtils.ObjectsToPut objectsToPut = com.spectralogic.ds3cli.util.FileUtils.getObjectsToPut(filesToPut, bulkPutLocalTempDir, true);
+            final com.spectralogic.ds3cli.util.FileUtils.ObjectsToPut objectsToPut = com.spectralogic.ds3cli.util.FileUtils.getObjectsToPut(filesToPut, bulkPutLocalTempDir, "", true);
             final Ds3Object obj = objectsToPut.getDs3Objects().get(0);
             assertTrue(obj.getSize() < 150);
             OUT.insertLog(obj.getName()  + " size: " + Long.toString(obj.getSize()));


### PR DESCRIPTION
It can be hard to find a system that can run this because it creates a huge directory of test files in TMP.  This allows you set the environment variable DS3_TEMP_DIR, and it will use that for the test data.