### PR TITLE
Fix for https://jira.spectralogic.com/browse/JAVACLI-169.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ subprojects {
     apply plugin: 'maven'
     apply plugin: 'idea'
 
+    sourceCompatibility = JavaVersion.VERSION_1_7
+
     repositories {
         mavenCentral()
         jcenter()

--- a/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
+++ b/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
@@ -399,6 +399,29 @@ public class FeatureIntegration_Test {
     }
 
     @Test
+    public void testGetBulkObjectWithDiscard() throws Exception {
+        final String bucketName = "test_get_bulk_with_discard";
+        try {
+            Files.createDirectories(Paths.get(Util.DOWNLOAD_BASE_NAME));
+            Util.createBucket(client, bucketName);
+            Util.loadBookTestData(client, bucketName);
+
+            final Arguments args = new Arguments(
+                    new String[]{
+                            "--http",
+                            "-c", "get_bulk",
+                            "-b", bucketName,
+                            "--discard"});
+            final CommandResponse response = Util.command(client, args);
+            assertThat(response.getMessage(), is("SUCCESS: Retrieved and discarded all objects from test_get_bulk_with_discard"));
+            assertEquals(Util.countLocalFiles(), 0);
+        } finally {
+            Util.deleteBucket(client, bucketName);
+            Util.deleteLocalFiles();
+        }
+    }
+
+    @Test
     public void getBulkObjectWithSync() throws Exception {
         final String bucketName = "test_get_bulk_object_with_sync_no_update";
         try {

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/LoggingFileObjectGetter.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/LoggingFileObjectGetter.java
@@ -43,8 +43,8 @@ public class LoggingFileObjectGetter implements LoggingObjectGetter {
     }
 
     @Override
-    public void metadataReceived(final String filename, final Metadata metadata) {
-        final Path path = outputPath.resolve(filename);
-        MetadataUtils.restoreLastModified(filename, metadata, path);
+    public void metadataReceived(final String fileName, final Metadata metadata) {
+        final Path path = outputPath.resolve(fileName);
+        MetadataUtils.restoreLastModified(fileName, metadata, path);
     }
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/LoggingMemoryObjectGetter.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/LoggingMemoryObjectGetter.java
@@ -17,34 +17,24 @@ package com.spectralogic.ds3cli.util;
 
 import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
 import com.spectralogic.ds3client.networking.Metadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.Path;
 
-public class LoggingFileObjectGetter implements LoggingObjectGetter {
+public class LoggingMemoryObjectGetter implements LoggingObjectGetter {
+    private final Ds3ClientHelpers.ObjectChannelBuilder objectChannelBuilder;
 
-    private final static Logger LOG = LoggerFactory.getLogger(LoggingFileObjectGetter.class);
-
-    final private Ds3ClientHelpers.ObjectChannelBuilder objectGetter;
-    final private Path outputPath;
-
-    public LoggingFileObjectGetter(final Ds3ClientHelpers.ObjectChannelBuilder getter, final Path outputPath) {
-        this.objectGetter = getter;
-        this.outputPath = outputPath;
+    public LoggingMemoryObjectGetter(final Ds3ClientHelpers.ObjectChannelBuilder objectChannelBuilder) {
+        this.objectChannelBuilder = objectChannelBuilder;
     }
 
     @Override
-    public SeekableByteChannel buildChannel(final String s) throws IOException {
-        LOG.info("Getting object {}", s);
-        return this.objectGetter.buildChannel(s);
+    public SeekableByteChannel buildChannel(final String channelName) throws IOException {
+        return objectChannelBuilder.buildChannel(channelName);
     }
 
     @Override
-    public void metadataReceived(final String filename, final Metadata metadata) {
-        final Path path = outputPath.resolve(filename);
-        MetadataUtils.restoreLastModified(filename, metadata, path);
+    public void metadataReceived(final String s, final Metadata metadata) {
+        // Intentionally not implemented
     }
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/LoggingMemoryObjectGetter.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/LoggingMemoryObjectGetter.java
@@ -34,7 +34,7 @@ public class LoggingMemoryObjectGetter implements LoggingObjectGetter {
     }
 
     @Override
-    public void metadataReceived(final String s, final Metadata metadata) {
+    public void metadataReceived(final String fileName, final Metadata metadata) {
         // Intentionally not implemented
     }
 }

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/LoggingObjectGetter.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/util/LoggingObjectGetter.java
@@ -1,0 +1,26 @@
+/*
+ * *****************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ***************************************************************************
+ */
+
+package com.spectralogic.ds3cli.util;
+
+import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
+import com.spectralogic.ds3client.helpers.MetadataReceivedListener;
+
+/**
+ * A marker interface to allow subclass creation from a factory
+ */
+public interface LoggingObjectGetter extends Ds3ClientHelpers.ObjectChannelBuilder, MetadataReceivedListener {
+    // Intentionally empty
+}


### PR DESCRIPTION
The logging channel used in bulk get was trying to read metadata from files
that are not created whe you specify the --discard flag.