### PR TITLE
Removing Bucket Scan with Piped Input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+sudo: false
+dist: trusty
 jdk:
-  - oraclejdk8
+  - openjdk8
 script: ./gradlew -S clean ds3_java_cli:test --info

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@
 
 buildscript {
 
+    buildscript {
+        ext.kotlin_version = '1.3.50'
+    }
+
     repositories {
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -23,6 +27,7 @@ buildscript {
 
     dependencies {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -54,6 +59,7 @@ subprojects {
         compile 'com.google.guava:guava:23.0-jre'
         compile 'com.spectralogic.ds3:ds3-sdk:5.0.5'
         compile 'com.google.inject:guice:4.2.0'
+        compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
 
         testCompile('org.mockito:mockito-core:1.10.19') {
             exclude group: 'org.hamcrest'

--- a/ds3_java_cli/build.gradle
+++ b/ds3_java_cli/build.gradle
@@ -17,6 +17,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 apply plugin: 'application'
+apply plugin: 'kotlin'
 
 mainClassName = 'com.spectralogic.ds3cli.Main'
 

--- a/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBucket.java
+++ b/ds3_java_cli/src/main/java/com/spectralogic/ds3cli/command/GetBucket.java
@@ -96,5 +96,4 @@ public class GetBucket extends CliCommand<GetBucketResult> {
             return new com.spectralogic.ds3cli.views.cli.GetBucketView();
         }
     }
-
 }

--- a/ds3_java_cli/src/main/kotlin/com/spectralogic/ds3cli/PipeUtils.kt
+++ b/ds3_java_cli/src/main/kotlin/com/spectralogic/ds3cli/PipeUtils.kt
@@ -1,0 +1,104 @@
+/*
+ * ***************************************************************************
+ *   Copyright 2014-2019 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ***************************************************************************
+ */
+
+package com.spectralogic.ds3cli
+
+import com.google.common.collect.ImmutableList
+import com.spectralogic.ds3cli.exceptions.CommandException
+import com.spectralogic.ds3client.Ds3Client
+import com.spectralogic.ds3client.commands.spectrads3.GetObjectDetailsSpectraS3Request
+import com.spectralogic.ds3client.models.Contents
+import com.spectralogic.ds3client.networking.FailedRequestException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import org.slf4j.LoggerFactory
+import java.io.IOException
+
+object PipeUtils {
+
+    private val LOG = LoggerFactory.getLogger(PipeUtils::class.java)
+
+    @JvmStatic
+    @Throws(CommandException::class)
+    fun getObjectsByPipe(pipedFileNames: ImmutableList<String>, client: Ds3Client, bucketName: String): Iterable<Contents> {
+        return runBlocking {
+
+            val fileDetails = supervisorScope {
+                 pipedFileNames.map { objName ->
+                    async(Dispatchers.IO) {
+                        try {
+                            val result = client.getObjectDetailsSpectraS3(GetObjectDetailsSpectraS3Request(objName, bucketName)).s3ObjectResult
+
+                            GetObjectResponse.Success(Contents().apply {
+                                key = result.name
+                                lastModified = result.creationDate
+                            })
+
+
+                        } catch (f: FailedRequestException) {
+                            if (f.statusCode == 404) {
+                                GetObjectResponse.NotFound(objName)
+                            } else {
+                                GetObjectResponse.Error(f)
+                            }
+                        } catch (e: IOException) {
+                            GetObjectResponse.Error(e)
+                        }
+                    }
+                }.awaitAll()
+            }
+
+            val errorBuilder = ImmutableList.builder<IOException>()
+            val notFoundBuilder = ImmutableList.builder<String>()
+            val contentBuilder = ImmutableList.builder<Contents>()
+
+            for (result in fileDetails) {
+                when (result) {
+                    is GetObjectResponse.Success -> contentBuilder.add(result.contents)
+                    is GetObjectResponse.NotFound -> notFoundBuilder.add(result.fileName)
+                    is GetObjectResponse.Error -> errorBuilder.add(result.t)
+                }
+            }
+
+            val errorList = errorBuilder.build()
+
+            if (errorList.isNotEmpty()) {
+
+                for (e in errorList) {
+                    LOG.error("Encountered an error while getting the object details", e)
+                }
+
+                throw CommandException("Encountered an unexpected error while attempting to get object details for piped files.")
+            }
+
+            val notFoundList = notFoundBuilder.build()
+
+            if (notFoundList.isNotEmpty()) {
+                throw CommandException("Could not find the following objects: ${notFoundList.joinToString(", ")}")
+            }
+
+            contentBuilder.build()
+        }
+   }
+
+    sealed class GetObjectResponse {
+        class Success(val contents: Contents): GetObjectResponse()
+        class NotFound(val fileName: String): GetObjectResponse()
+        class Error(val t: IOException): GetObjectResponse()
+    }
+}


### PR DESCRIPTION
Updating the way we perform the scan to determine if a file exists when using piped input.  Rather than scanning the full bucket to see if call the files exist, we query each file independently in parallel and then perform any error checking.