### PR TITLE
Fixing bulk_get so that objects with names ending in '.json' can be retrieved

### DIFF
--- a/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
+++ b/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
@@ -904,7 +904,7 @@ public class FeatureIntegration_Test {
             Util.createBucket(client, bucketName);
             Util.loadBookTestData(client, bucketName);
 
-            final String pipedInput = "beowulf.txt\nulysses.txt";
+            final String pipedInput = "beowulf.txt\nulysses.txt\ntest.json";
             final InputStream testFile = new ByteArrayInputStream(pipedInput.getBytes("UTF-8"));
             System.setIn(testFile);
 

--- a/ds3-cli-integration/src/test/resources/books/test.json
+++ b/ds3-cli-integration/src/test/resources/books/test.json
@@ -1,0 +1,1 @@
+Testing if the CLI hates files with json extension


### PR DESCRIPTION
The BP API has a feature where if the path ends in '.json' then the response payload will be returned in json format. The java SDK assumes that all response payloads will be formatted in xml. As a consequence, certain API calls cannot be made using the SDK against objects with names ending in '.json'. One of these calls is GetObjectDetails (singular), which is used to pre-process user input before performing a bulk_get. To work around this BP feature, the call is being updated to GetObjectsWithFullDetails (plural) where the object name is specified as a query parameter rather than part of the path. The original code did not support versioning, so neither does this update. If there are multiple versions of an object, an error will be returned for that object.