### PR TITLE
The sync test intermittently fails if the BP's clock is a few milliseconds off from the client running the tests

### DIFF
--- a/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
+++ b/ds3-cli-integration/src/test/java/com/spectralogic/ds3cli/integration/FeatureIntegration_Test.java
@@ -371,7 +371,7 @@ public class FeatureIntegration_Test {
             Util.createBucket(client, bucketName);
             Util.loadBookTestData(client, bucketName);
             final File newFile = new File(Util.DOWNLOAD_BASE_NAME + File.separator + objectName);
-            final DateTime now = new DateTime();
+            final DateTime now = new DateTime().plusHours(1);
             newFile.setLastModified(now.getMillis());
 
             final Arguments args = new Arguments(


### PR DESCRIPTION
Increasing the time difference in the test to make it less sensitive to clock differences.