### PR TITLE
Improving performance of bulk_get

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
 }
 
 allprojects {
-    version = '5.1.3'
+    version = '5.1.4'
     group = 'com.spectralogic'
 
     repositories {


### PR DESCRIPTION
- Revving version for new CLI release
- When retrieving an object with a name ending in '.json', perform the slightly less expensive GetObjectsDetails (plural) call as opposed to the GetObjectsWithFullDetails call. When retrieving all other objects, perform the inexpensive GetObjectDetails (singular) call. Retrieving objects whose name ends in '.json' will incur a performance hit, but this bypasses the json payload format issue that otherwise prevents response payload unmarshaling.