### PR TITLE
Comment out suppression file in owasp config

### DIFF
--- a/buildSrc/src/main/kotlin/owasp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/owasp-conventions.gradle.kts
@@ -21,7 +21,7 @@ dependencyCheck {
     skipConfigurations = listOf("ktlint", "ktlintBaselineReporter", "detekt")
     // fail the build if any vulnerable dependencies are identified (CVSS score > 0)
     failBuildOnCVSS = 0F
-    suppressionFile = "project_files/owasp/dependency-check-suppression.xml"
+    //suppressionFile = "project_files/owasp/dependency-check-suppression.xml"
     // node audit for yarn was recently enabled and it's not quite working yet.
     // try again when updating the dependency check plugin.
     // last tried: v8.1.2


### PR DESCRIPTION
We do not have a dependency check suppression file for this project yet, so comment it out of the owasp configuration.